### PR TITLE
Replace find_by_name with find_all_by_name

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -183,15 +183,16 @@ impl GeneralTaxonomy {
         Ok(tax)
     }
 
-    /// Retrieves the external ID given its name
+    /// Retrieves all external IDs given a name
     ///
     /// Always return `None` on Newick since it doesn't contain names.
-    pub fn find_by_name(&self, name: &str) -> Option<&str> {
-        if let Some(pos) = self.names.iter().position(|s| s == name) {
-            Some(&self.tax_ids[pos])
-        } else {
-            None
-        }
+    pub fn find_all_by_name(&self, name: &str) -> Vec<&std::string::String> {
+        self.names
+            .iter()
+            .enumerate()
+            .filter(|(_, val)| val == &name)
+            .map(|(pos, _)| &self.tax_ids[pos])
+            .collect::<Vec<&std::string::String>>()
     }
 
     /// Add a new node to the taxonomy.
@@ -394,12 +395,16 @@ mod tests {
                 {"id": "1", "name": "root", "readcount": 1000},
                 {"id": "2", "name": "Bacteria", "rank": "no rank", "readcount": 1000},
                 {"id": "562", "name": "Escherichia coli", "rank": "species", "readcount": 1000},
-                {"id": "1000", "name": "Covid", "rank": "", "readcount": 1000}
+                {"id": "1000", "name": "Covid", "rank": "", "readcount": 1000},
+                {"id": "101", "name": "Proteus", "rank": "", "readcount": 1000},
+                {"id": "102", "name": "Proteus", "rank": "", "readcount": 1000}
             ],
             "links": [
                 {"source": 1, "target": 0},
                 {"source": 2, "target": 1},
-                {"source": 3, "target": 0}
+                {"source": 3, "target": 0},
+                {"source": 4, "target": 0},
+                {"source": 5, "target": 0}
             ]
         }"#;
 
@@ -409,18 +414,20 @@ mod tests {
     #[test]
     fn implements_taxonomy_correctly() {
         let tax = create_test_taxonomy();
-        assert_eq!(Taxonomy::<&str>::len(&tax), 4);
-        assert_eq!(tax.children("1").unwrap(), vec!["2", "1000"]);
+        assert_eq!(Taxonomy::<&str>::len(&tax), 6);
+        assert_eq!(tax.children("1").unwrap(), vec!["2", "1000", "101", "102"]);
         assert_eq!(tax.name("562").unwrap(), "Escherichia coli");
         assert_eq!(tax.rank("562").unwrap(), TaxRank::Species);
         assert_eq!(tax.parent("562").unwrap(), Some(("2", 1.0)));
     }
 
     #[test]
-    fn can_find_by_name() {
+    fn can_find_all_by_name() {
         let tax = create_test_taxonomy();
-        let res = tax.find_by_name("Bacteria");
-        assert_eq!(res, Some("2"));
+        let res = tax.find_all_by_name("Bacteria");
+        assert_eq!(res, vec!["2"]);
+        let res = tax.find_all_by_name("Proteus");
+        assert_eq!(res, vec!["101", "102"]);
     }
 
     #[test]

--- a/src/base.rs
+++ b/src/base.rs
@@ -184,15 +184,16 @@ impl GeneralTaxonomy {
     }
 
     /// Retrieves all external IDs given a name
-    ///
-    /// Always return `None` on Newick since it doesn't contain names.
-    pub fn find_all_by_name(&self, name: &str) -> Vec<&std::string::String> {
-        self.names
+    pub fn find_all_by_name(&self, name: &str) -> Vec<&str> {
+        let name_indices = self
+            .names
             .iter()
             .enumerate()
             .filter(|(_, val)| val == &name)
-            .map(|(pos, _)| &self.tax_ids[pos])
-            .collect::<Vec<&std::string::String>>()
+            .map(|(pos, _)| pos)
+            .collect::<Vec<usize>>();
+
+        name_indices.iter().map(|&pos| &self.tax_ids[pos] as &str).collect()
     }
 
     /// Add a new node to the taxonomy.

--- a/src/base.rs
+++ b/src/base.rs
@@ -193,7 +193,10 @@ impl GeneralTaxonomy {
             .map(|(pos, _)| pos)
             .collect::<Vec<usize>>();
 
-        name_indices.iter().map(|&pos| &self.tax_ids[pos] as &str).collect()
+        name_indices
+            .iter()
+            .map(|&pos| &self.tax_ids[pos] as &str)
+            .collect()
     }
 
     /// Add a new node to the taxonomy.
@@ -346,10 +349,7 @@ impl<'t> Taxonomy<'t, InternalIndex> for GeneralTaxonomy {
         if idx >= self.parent_ids.len() {
             return Err(Error::new(ErrorKind::NoSuchInternalIndex(idx)));
         }
-        Ok(Some((
-            self.parent_ids[idx as usize],
-            self.parent_distances[idx as usize],
-        )))
+        Ok(Some((self.parent_ids[idx], self.parent_distances[idx])))
     }
 
     fn name(&'t self, idx: InternalIndex) -> TaxonomyResult<&str> {

--- a/src/python.rs
+++ b/src/python.rs
@@ -273,16 +273,17 @@ impl Taxonomy {
         self.as_node(tax_id).ok()
     }
 
-    /// find_by_name(self, name: str) -> TaxonomyNode
+    /// find_all_by_name(self, name: str) -> List[TaxonomyNode]
     /// --
     ///
     /// Find a node by its name, Raises an exception if not found.
-    fn find_by_name(&self, name: &str) -> Option<TaxonomyNode> {
-        if let Some(tax_id) = self.tax.find_by_name(name) {
-            self.as_node(tax_id).ok()
-        } else {
-            None
-        }
+    fn find_all_by_name(&self, name: &str) -> PyResult<Vec<TaxonomyNode>> {
+        Ok(self
+            .tax
+            .find_all_by_name(name)
+            .iter()
+            .map(|tax_id| self.as_node(tax_id).unwrap())
+            .collect::<Vec<TaxonomyNode>>())
     }
 
     /// parent_with_distance(self, tax_id: str, /, at_rank: str)

--- a/test_python.py
+++ b/test_python.py
@@ -62,6 +62,11 @@ JSON_DATA = """
       "name": "species 1.1",
       "rank": "species",
       "id": 10
+    },
+    {
+      "name": "species 1.1",
+      "rank": "species",
+      "id": 12
     }
   ],
   "links": [
@@ -104,6 +109,10 @@ JSON_DATA = """
     {
       "source": 2,
       "target": 0
+    },
+    {
+      "source": 11,
+      "target": 4
     }
   ]
 }        """
@@ -123,6 +132,11 @@ class JsonTestCase(unittest.TestCase):
                 for x in ["1", "9", "2", "11", "8", "5", "3", "4", "6", "7", "10"]
             ],
             [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        )
+
+    def test_find_all_by_name(self):
+        self.assertEqual(
+            sorted([n.id for n in self.tax.find_all_by_name("species 1.1")]), ["10", "12"]
         )
 
 
@@ -160,10 +174,10 @@ class NewickTestCase(unittest.TestCase):
         with self.assertRaises(TaxonomyError):
             _ = self.tax["unknown"]
 
-    def test_find_by_name(self):
+    def test_find_all_by_name(self):
         # They are not named so we can't find anything by name
-        node = self.tax.find_by_name("A")
-        self.assertIsNone(node)
+        nodes = self.tax.find_all_by_name("A")
+        self.assertEqual(nodes, [])
 
     def test_parent(self):
         parent = self.tax.parent("D")
@@ -265,10 +279,10 @@ class NCBITestCase(unittest.TestCase):
             _ = self.tax["unknown"]
 
     def test_find_by_name(self):
-        node = self.tax.find_by_name("Escherichia coli")
-        self.assertEqual(node.id, "562")
-        self.assertEqual(node.name, "Escherichia coli")
-        self.assertEqual(node.parent, "561")
+        nodes = self.tax.find_all_by_name("Escherichia coli")
+        self.assertEqual([n.id for n in nodes], ["562"])
+        self.assertEqual([n.name for n in nodes], ["Escherichia coli"])
+        self.assertEqual([n.parent for n in nodes], ["561"])
 
     def test_parent(self):
         parent = self.tax.parent("562")

--- a/test_python.py
+++ b/test_python.py
@@ -278,7 +278,7 @@ class NCBITestCase(unittest.TestCase):
         with self.assertRaises(TaxonomyError):
             _ = self.tax["unknown"]
 
-    def test_find_by_name(self):
+    def test_find_all_by_name(self):
         nodes = self.tax.find_all_by_name("Escherichia coli")
         self.assertEqual([n.id for n in nodes], ["562"])
         self.assertEqual([n.name for n in nodes], ["Escherichia coli"])


### PR DESCRIPTION
Taxonomies commonly have duplicate names (["Proteus" is in bacteria and salamanders](https://www.ncbi.nlm.nih.gov/search/all/?term=Proteus)). Currently, `find_by_name` will return the first name it matches. This PR replaces `find_by_name` with `find_all_by_name` which returns a list of matches (an empty list if none are found).