### PR TITLE
Bugfix: actual Python exception instead of panic

### DIFF
--- a/test_python.py
+++ b/test_python.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 from taxonomy import Taxonomy, TaxonomyError
@@ -156,6 +157,29 @@ class JsonTestCase(unittest.TestCase):
         tax.edit_node("5", parent_id="1")
         pruned = tax.prune(keep=["5"])
         assert pruned["5"].parent == "1"
+
+    def test_to_json_tree(self):
+        small_tax = self.tax.prune(remove=[str(i) for i in range(3, 12)])
+        actual = json.loads(small_tax.to_json_tree().decode())
+        expected = {
+            "id": "1",
+            "name": "root",
+            "rank": "no rank",
+            "children": [
+                {
+                    "id": "2",
+                    "name": "superkingdom 1",
+                    "rank": "superkingdom",
+                    "children": [],
+                }
+            ],
+        }
+        self.assertEqual(actual, expected)
+
+    def test_to_json_tree_with_empty_tree(self):
+        empty_tax = self.tax.prune(keep=[])
+        with self.assertRaises(TaxonomyError):
+            empty_tax.to_json_tree()
 
 
 class NewickTestCase(unittest.TestCase):

--- a/test_python.py
+++ b/test_python.py
@@ -160,7 +160,7 @@ class JsonTestCase(unittest.TestCase):
 
     def test_to_json_tree(self):
         small_tax = self.tax.prune(remove=[str(i) for i in range(3, 12)])
-        actual = json.loads(small_tax.to_json_tree().decode())
+        actual = json.loads(small_tax.to_json_tree())
         expected = {
             "id": "1",
             "name": "root",
@@ -180,6 +180,18 @@ class JsonTestCase(unittest.TestCase):
         empty_tax = self.tax.prune(keep=[])
         with self.assertRaises(TaxonomyError):
             empty_tax.to_json_tree()
+
+    def test_to_json_node_links_empty_tree(self):
+        empty_tax = self.tax.prune(keep=[])
+        actual = json.loads(empty_tax.to_json_node_links())
+        expected = {
+            "directed": True,
+            "graph": [],
+            "links": [],
+            "multigraph": False,
+            "nodes": [],
+        }
+        self.assertEqual(actual, expected)
 
 
 class NewickTestCase(unittest.TestCase):


### PR DESCRIPTION
`to_json_node_links` should work because we allow to import empty taxonomy. So we should be able to save/load the same taxonomy.

You can't import a taxonomy using tree format if it is empty. So `to_json_tree` from now on fails with a proper Python exception instead of just panicking.