### PR TITLE
including full annotations at nodes and exporting to ncbi, json, newick formats

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -3,13 +3,156 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 
-use serde_json::Value;
-
 use crate::errors::{Error, ErrorKind, TaxonomyResult};
 use crate::rank::TaxRank;
 use crate::taxonomy::Taxonomy;
 
 pub type InternalIndex = usize;
+
+/// Native Rust type for storing arbitrary taxonomy data without serde dependency
+#[derive(Clone, Debug, PartialEq)]
+pub enum TaxonomyValue {
+    String(String),
+    Integer(i64),
+    Float(f64),
+    Bool(bool),
+    Array(Vec<TaxonomyValue>),
+    Object(HashMap<String, TaxonomyValue>),
+    Null,
+}
+
+impl TaxonomyValue {
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            TaxonomyValue::String(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn as_i64(&self) -> Option<i64> {
+        match self {
+            TaxonomyValue::Integer(i) => Some(*i),
+            _ => None,
+        }
+    }
+
+    pub fn as_f64(&self) -> Option<f64> {
+        match self {
+            TaxonomyValue::Float(f) => Some(*f),
+            TaxonomyValue::Integer(i) => Some(*i as f64),
+            _ => None,
+        }
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        match self {
+            TaxonomyValue::Bool(b) => Some(*b),
+            _ => None,
+        }
+    }
+
+    pub fn as_array(&self) -> Option<&Vec<TaxonomyValue>> {
+        match self {
+            TaxonomyValue::Array(arr) => Some(arr),
+            _ => None,
+        }
+    }
+
+    pub fn as_array_mut(&mut self) -> Option<&mut Vec<TaxonomyValue>> {
+        match self {
+            TaxonomyValue::Array(arr) => Some(arr),
+            _ => None,
+        }
+    }
+
+    pub fn as_object(&self) -> Option<&HashMap<String, TaxonomyValue>> {
+        match self {
+            TaxonomyValue::Object(obj) => Some(obj),
+            _ => None,
+        }
+    }
+
+    pub fn is_null(&self) -> bool {
+        matches!(self, TaxonomyValue::Null)
+    }
+}
+
+// Conversion functions for interop with serde_json (used only in format modules)
+impl From<serde_json::Value> for TaxonomyValue {
+    fn from(value: serde_json::Value) -> Self {
+        match value {
+            serde_json::Value::String(s) => TaxonomyValue::String(s),
+            serde_json::Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    TaxonomyValue::Integer(i)
+                } else if let Some(f) = n.as_f64() {
+                    TaxonomyValue::Float(f)
+                } else {
+                    TaxonomyValue::Null
+                }
+            }
+            serde_json::Value::Bool(b) => TaxonomyValue::Bool(b),
+            serde_json::Value::Array(arr) => {
+                TaxonomyValue::Array(arr.into_iter().map(TaxonomyValue::from).collect())
+            }
+            serde_json::Value::Object(obj) => TaxonomyValue::Object(
+                obj.into_iter()
+                    .map(|(k, v)| (k, TaxonomyValue::from(v)))
+                    .collect(),
+            ),
+            serde_json::Value::Null => TaxonomyValue::Null,
+        }
+    }
+}
+
+impl From<TaxonomyValue> for serde_json::Value {
+    fn from(value: TaxonomyValue) -> Self {
+        match value {
+            TaxonomyValue::String(s) => serde_json::Value::String(s),
+            TaxonomyValue::Integer(i) => {
+                serde_json::Value::Number(serde_json::Number::from(i))
+            }
+            TaxonomyValue::Float(f) => serde_json::Value::Number(
+                serde_json::Number::from_f64(f).unwrap_or(serde_json::Number::from(0)),
+            ),
+            TaxonomyValue::Bool(b) => serde_json::Value::Bool(b),
+            TaxonomyValue::Array(arr) => {
+                serde_json::Value::Array(arr.into_iter().map(serde_json::Value::from).collect())
+            }
+            TaxonomyValue::Object(obj) => serde_json::Value::Object(
+                obj.into_iter()
+                    .map(|(k, v)| (k, serde_json::Value::from(v)))
+                    .collect(),
+            ),
+            TaxonomyValue::Null => serde_json::Value::Null,
+        }
+    }
+}
+
+// Also provide borrowed conversions
+impl From<&TaxonomyValue> for serde_json::Value {
+    fn from(value: &TaxonomyValue) -> Self {
+        match value {
+            TaxonomyValue::String(s) => serde_json::Value::String(s.clone()),
+            TaxonomyValue::Integer(i) => {
+                serde_json::Value::Number(serde_json::Number::from(*i))
+            }
+            TaxonomyValue::Float(f) => serde_json::Value::Number(
+                serde_json::Number::from_f64(*f).unwrap_or(serde_json::Number::from(0)),
+            ),
+            TaxonomyValue::Bool(b) => serde_json::Value::Bool(*b),
+            TaxonomyValue::Array(arr) => {
+                serde_json::Value::Array(arr.iter().map(serde_json::Value::from).collect())
+            }
+            TaxonomyValue::Object(obj) => serde_json::Value::Object(
+                obj.iter()
+                    .map(|(k, v)| (k.clone(), serde_json::Value::from(v)))
+                    .collect(),
+            ),
+            TaxonomyValue::Null => serde_json::Value::Null,
+        }
+    }
+}
 
 /// The type that is returned when loading any taxonomies through that library.
 /// It include 2 implementations of the [Taxonomy] trait: one using strings as ids
@@ -22,8 +165,8 @@ pub struct GeneralTaxonomy {
     pub parent_distances: Vec<f32>,
     pub names: Vec<String>,
     pub ranks: Vec<TaxRank>,
-    // Only used by the JSON format
-    pub data: Vec<HashMap<String, Value>>,
+    // Arbitrary data stored for each node using native Rust types
+    pub data: Vec<HashMap<String, TaxonomyValue>>,
 
     // Lookup tables that can dramatically speed up some operations
     pub(crate) tax_id_lookup: HashMap<String, InternalIndex>,
@@ -168,7 +311,7 @@ impl GeneralTaxonomy {
         names: Option<Vec<String>>,
         ranks: Option<Vec<TaxRank>>,
         distances: Option<Vec<f32>>,
-        data: Option<Vec<HashMap<String, Value>>>,
+        data: Option<Vec<HashMap<String, TaxonomyValue>>>,
     ) -> TaxonomyResult<Self> {
         let size = tax_ids.len();
         let adj_names = names.unwrap_or_else(|| vec![String::new(); tax_ids.len()]);
@@ -352,7 +495,7 @@ impl<'t> Taxonomy<'t, &'t str> for GeneralTaxonomy {
         Ok(&self.names[idx])
     }
 
-    fn data(&'t self, tax_id: &str) -> TaxonomyResult<Cow<'t, HashMap<String, Value>>> {
+    fn data(&'t self, tax_id: &str) -> TaxonomyResult<Cow<'t, HashMap<String, TaxonomyValue>>> {
         let idx = self.to_internal_index(tax_id)?;
         Ok(Cow::Borrowed(&self.data[idx]))
     }
@@ -415,7 +558,7 @@ impl<'t> Taxonomy<'t, InternalIndex> for GeneralTaxonomy {
         }
     }
 
-    fn data(&'t self, idx: InternalIndex) -> TaxonomyResult<Cow<'t, HashMap<String, Value>>> {
+    fn data(&'t self, idx: InternalIndex) -> TaxonomyResult<Cow<'t, HashMap<String, TaxonomyValue>>> {
         if let Some(data) = self.data.get(idx) {
             Ok(Cow::Borrowed(data))
         } else {

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,4 +1,3 @@
-use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
@@ -109,9 +108,7 @@ impl From<TaxonomyValue> for serde_json::Value {
     fn from(value: TaxonomyValue) -> Self {
         match value {
             TaxonomyValue::String(s) => serde_json::Value::String(s),
-            TaxonomyValue::Integer(i) => {
-                serde_json::Value::Number(serde_json::Number::from(i))
-            }
+            TaxonomyValue::Integer(i) => serde_json::Value::Number(serde_json::Number::from(i)),
             TaxonomyValue::Float(f) => serde_json::Value::Number(
                 serde_json::Number::from_f64(f).unwrap_or(serde_json::Number::from(0)),
             ),
@@ -134,9 +131,7 @@ impl From<&TaxonomyValue> for serde_json::Value {
     fn from(value: &TaxonomyValue) -> Self {
         match value {
             TaxonomyValue::String(s) => serde_json::Value::String(s.clone()),
-            TaxonomyValue::Integer(i) => {
-                serde_json::Value::Number(serde_json::Number::from(*i))
-            }
+            TaxonomyValue::Integer(i) => serde_json::Value::Number(serde_json::Number::from(*i)),
             TaxonomyValue::Float(f) => serde_json::Value::Number(
                 serde_json::Number::from_f64(*f).unwrap_or(serde_json::Number::from(0)),
             ),
@@ -158,7 +153,7 @@ impl From<&TaxonomyValue> for serde_json::Value {
 /// It include 2 implementations of the [Taxonomy] trait: one using strings as ids
 /// (easier to use but slower) and one using internal indices (harder to use but faster).
 /// Most fields are public for flexibility reason.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GeneralTaxonomy {
     pub tax_ids: Vec<String>,
     pub parent_ids: Vec<InternalIndex>,
@@ -363,13 +358,39 @@ impl GeneralTaxonomy {
 
     /// Retrieves all external IDs given a name
     pub fn find_all_by_name(&self, name: &str) -> Vec<&str> {
-        let name_indices = self
+        let mut name_indices = self
             .names
             .iter()
             .enumerate()
             .filter(|(_, val)| val == &name)
             .map(|(pos, _)| pos)
             .collect::<Vec<usize>>();
+
+        // Also search alternative names in the data field
+        for (idx, node_data) in self.data.iter().enumerate() {
+            if name_indices.contains(&idx) {
+                continue; // Already found by scientific name
+            }
+
+            if let Some(names_value) = node_data.get("names") {
+                if let Some(names_array) = names_value.as_array() {
+                    let has_match = names_array.iter().any(|name_obj| {
+                        if let Some(name_map) = name_obj.as_object() {
+                            if let Some(name_text) = name_map.get("name_text") {
+                                if let Some(text) = name_text.as_str() {
+                                    return text == name;
+                                }
+                            }
+                        }
+                        false
+                    });
+
+                    if has_match {
+                        name_indices.push(idx);
+                    }
+                }
+            }
+        }
 
         name_indices
             .iter()
@@ -558,7 +579,10 @@ impl<'t> Taxonomy<'t, InternalIndex> for GeneralTaxonomy {
         }
     }
 
-    fn data(&'t self, idx: InternalIndex) -> TaxonomyResult<Cow<'t, HashMap<String, TaxonomyValue>>> {
+    fn data(
+        &'t self,
+        idx: InternalIndex,
+    ) -> TaxonomyResult<Cow<'t, HashMap<String, TaxonomyValue>>> {
         if let Some(data) = self.data.get(idx) {
             Ok(Cow::Borrowed(data))
         } else {

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -844,13 +844,22 @@ mod tests {
         // Verify we can reload from streaming output
         let tax2 = load(Cursor::new(&streaming_output[..]), None).unwrap();
         assert_eq!(Taxonomy::<&str>::len(&tax2), 3);
-        assert_eq!(Taxonomy::<&str>::name(&tax2, "562").unwrap(), "Escherichia coli");
+        assert_eq!(
+            Taxonomy::<&str>::name(&tax2, "562").unwrap(),
+            "Escherichia coli"
+        );
 
         // Verify extra data is preserved
         let data = Taxonomy::<&str>::data(&tax2, "562").unwrap();
-        assert_eq!(data.get("genetic_code_id").and_then(|v| v.as_str()), Some("11"));
+        assert_eq!(
+            data.get("genetic_code_id").and_then(|v| v.as_str()),
+            Some("11")
+        );
         assert_eq!(data.get("embl_code").and_then(|v| v.as_str()), Some("EC"));
-        assert_eq!(data.get("name_common_name").and_then(|v| v.as_str()), Some("E. coli"));
+        assert_eq!(
+            data.get("name_common_name").and_then(|v| v.as_str()),
+            Some("E. coli")
+        );
     }
 
     #[test]
@@ -883,9 +892,18 @@ mod tests {
         let tax2 = load(Cursor::new(&streaming_output[..]), None).unwrap();
         let data = Taxonomy::<&str>::data(&tax2, "562").unwrap();
 
-        assert_eq!(data.get("genetic_code_id").and_then(|v| v.as_str()), Some("11"));
-        assert_eq!(data.get("name_common_name").and_then(|v| v.as_str()), Some("E. coli"));
-        assert_eq!(data.get("name_synonym").and_then(|v| v.as_str()), Some("Bacterium coli"));
+        assert_eq!(
+            data.get("genetic_code_id").and_then(|v| v.as_str()),
+            Some("11")
+        );
+        assert_eq!(
+            data.get("name_common_name").and_then(|v| v.as_str()),
+            Some("E. coli")
+        );
+        assert_eq!(
+            data.get("name_synonym").and_then(|v| v.as_str()),
+            Some("Bacterium coli")
+        );
         assert_eq!(data.get("comments").and_then(|v| v.as_str()), Some(""));
     }
 }

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -426,18 +426,16 @@ where
         to_writer(&mut *writer, value)?;
     }
 
-    // Write children
+    // Write children (always include, even if empty, to match regular format)
     let children = tax.children(tax_id)?;
-    if !children.is_empty() {
-        write!(writer, ",\"children\":[")?;
-        for (i, child) in children.into_iter().enumerate() {
-            if i > 0 {
-                write!(writer, ",")?;
-            }
-            write_node_streaming(tax, child, writer)?;
+    write!(writer, ",\"children\":[")?;
+    for (i, child) in children.into_iter().enumerate() {
+        if i > 0 {
+            write!(writer, ",")?;
         }
-        write!(writer, "]")?;
+        write_node_streaming(tax, child, writer)?;
     }
+    write!(writer, "]")?;
 
     write!(writer, "}}")?;
     Ok(())

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -369,6 +369,80 @@ where
     Ok(())
 }
 
+/// Memory-efficient streaming tree export that writes JSON incrementally
+/// instead of building the entire tree structure in memory first.
+pub fn save_tree_streaming<'t, W: Write, T: 't, X: Taxonomy<'t, T>>(
+    mut writer: W,
+    taxonomy: &'t X,
+    root_node: Option<T>,
+) -> TaxonomyResult<()>
+where
+    T: Clone + Debug + Display + Eq + Hash + PartialEq,
+{
+    let tax_id = root_node
+        .or_else(|| {
+            if taxonomy.is_empty() {
+                None
+            } else {
+                Some(taxonomy.root())
+            }
+        })
+        .ok_or(Error::new(ErrorKind::InvalidTaxonomy(
+            "Taxonomy must have a root node.".to_string(),
+        )))?;
+
+    write_node_streaming(taxonomy, tax_id, &mut writer)?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn write_node_streaming<'t, W: Write, T: 't>(
+    tax: &'t impl Taxonomy<'t, T>,
+    tax_id: T,
+    writer: &mut W,
+) -> TaxonomyResult<()>
+where
+    T: Clone + Debug + Display + Eq + Hash + PartialEq,
+{
+    write!(writer, "{{")?;
+
+    // Write id
+    write!(writer, "\"id\":")?;
+    to_writer(&mut *writer, &tax_id.to_string())?;
+
+    // Write name
+    write!(writer, ",\"name\":")?;
+    to_writer(&mut *writer, &tax.name(tax_id.clone())?)?;
+
+    // Write rank
+    write!(writer, ",\"rank\":")?;
+    to_writer(&mut *writer, tax.rank(tax_id.clone())?.to_ncbi_rank())?;
+
+    // Write extra data fields
+    let data = tax.data(tax_id.clone())?;
+    for (key, value) in data.iter() {
+        write!(writer, ",{}", serde_json::to_string(key)?)?;
+        write!(writer, ":")?;
+        to_writer(&mut *writer, value)?;
+    }
+
+    // Write children
+    let children = tax.children(tax_id)?;
+    if !children.is_empty() {
+        write!(writer, ",\"children\":[")?;
+        for (i, child) in children.into_iter().enumerate() {
+            if i > 0 {
+                write!(writer, ",")?;
+            }
+            write_node_streaming(tax, child, writer)?;
+        }
+        write!(writer, "]")?;
+    }
+
+    write!(writer, "}}")?;
+    Ok(())
+}
+
 fn serialize_as_tree<'t, T: 't>(
     taxonomy: &'t impl Taxonomy<'t, T>,
     root_node: Option<T>,
@@ -719,5 +793,99 @@ mod tests {
     fn can_handle_null_ranks() {
         let example = r#"{"id": "1", "rank": null, "name": ""}"#;
         assert!(load(Cursor::new(example), None).is_ok());
+    }
+
+    #[test]
+    fn streaming_tree_matches_regular_tree() {
+        // Create a taxonomy with multiple nodes and extra data
+        let example = r#"{
+            "id": "1",
+            "name": "root",
+            "rank": "no rank",
+            "custom_field": "value1",
+            "children": [
+                {
+                    "id": "2",
+                    "name": "Bacteria",
+                    "rank": "superkingdom",
+                    "genetic_code_id": "11",
+                    "children": [
+                        {
+                            "id": "562",
+                            "name": "Escherichia coli",
+                            "rank": "species",
+                            "genetic_code_id": "11",
+                            "embl_code": "EC",
+                            "division_id": "0",
+                            "name_common_name": "E. coli"
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let tax = load(Cursor::new(example), None).unwrap();
+
+        // Save using regular method
+        let mut regular_output = Vec::new();
+        save::<_, &str, _>(&mut regular_output, &tax, JsonFormat::Tree, None).unwrap();
+
+        // Save using streaming method
+        let mut streaming_output = Vec::new();
+        save_tree_streaming::<_, &str, _>(&mut streaming_output, &tax, None).unwrap();
+
+        // Parse both outputs
+        let regular_json: Value = serde_json::from_slice(&regular_output).unwrap();
+        let streaming_json: Value = serde_json::from_slice(&streaming_output).unwrap();
+
+        // They should be equivalent
+        assert_eq!(regular_json, streaming_json);
+
+        // Verify we can reload from streaming output
+        let tax2 = load(Cursor::new(&streaming_output[..]), None).unwrap();
+        assert_eq!(Taxonomy::<&str>::len(&tax2), 3);
+        assert_eq!(Taxonomy::<&str>::name(&tax2, "562").unwrap(), "Escherichia coli");
+
+        // Verify extra data is preserved
+        let data = Taxonomy::<&str>::data(&tax2, "562").unwrap();
+        assert_eq!(data.get("genetic_code_id").and_then(|v| v.as_str()), Some("11"));
+        assert_eq!(data.get("embl_code").and_then(|v| v.as_str()), Some("EC"));
+        assert_eq!(data.get("name_common_name").and_then(|v| v.as_str()), Some("E. coli"));
+    }
+
+    #[test]
+    fn streaming_handles_large_data_fields() {
+        // Test that streaming handles nodes with lots of extra fields (like NCBI data)
+        let example = r#"{
+            "id": "562",
+            "name": "Escherichia coli",
+            "rank": "species",
+            "genetic_code_id": "11",
+            "division_id": "0",
+            "inherited_div_flag": "1",
+            "mitochondrial_genetic_code_id": "0",
+            "inherited_MGC_flag": "1",
+            "GenBank_hidden_flag": "0",
+            "hidden_subtree_root_flag": "0",
+            "comments": "",
+            "name_scientific_name": "Escherichia coli",
+            "name_common_name": "E. coli",
+            "name_synonym": "Bacterium coli",
+            "name_authority": "Escherichia coli (Migula 1895) Castellani and Chalmers 1919"
+        }"#;
+
+        let tax = load(Cursor::new(example), None).unwrap();
+
+        let mut streaming_output = Vec::new();
+        save_tree_streaming::<_, &str, _>(&mut streaming_output, &tax, None).unwrap();
+
+        // Reload and verify all fields preserved
+        let tax2 = load(Cursor::new(&streaming_output[..]), None).unwrap();
+        let data = Taxonomy::<&str>::data(&tax2, "562").unwrap();
+
+        assert_eq!(data.get("genetic_code_id").and_then(|v| v.as_str()), Some("11"));
+        assert_eq!(data.get("name_common_name").and_then(|v| v.as_str()), Some("E. coli"));
+        assert_eq!(data.get("name_synonym").and_then(|v| v.as_str()), Some("Bacterium coli"));
+        assert_eq!(data.get("comments").and_then(|v| v.as_str()), Some(""));
     }
 }

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use std::io::{Read, Write};
 use std::str::FromStr;
 
-use crate::base::GeneralTaxonomy;
+use crate::base::{GeneralTaxonomy, TaxonomyValue};
 use crate::errors::{Error, ErrorKind, TaxonomyResult};
 use crate::rank::TaxRank;
 use crate::Taxonomy;
@@ -210,14 +210,20 @@ fn load_node_link_json(tax_json: &Value) -> TaxonomyResult<GeneralTaxonomy> {
     let mut tax_ids: Vec<String> = Vec::with_capacity(tax_nodes.len());
     let mut names: Vec<String> = Vec::with_capacity(tax_nodes.len());
     let mut ranks: Vec<TaxRank> = Vec::with_capacity(tax_nodes.len());
-    let mut data: Vec<HashMap<String, Value>> = Vec::with_capacity(tax_nodes.len());
+    let mut data: Vec<HashMap<String, TaxonomyValue>> = Vec::with_capacity(tax_nodes.len());
     let mut parent_ids = vec![0; tax_nodes.len()];
 
     for node in tax_nodes {
         tax_ids.push(node.id);
         names.push(node.name);
         ranks.push(node.rank);
-        data.push(node.extra);
+        // Convert from serde_json::Value to TaxonomyValue
+        data.push(
+            node.extra
+                .into_iter()
+                .map(|(k, v)| (k, TaxonomyValue::from(v)))
+                .collect(),
+        );
     }
 
     for l in tax_links {
@@ -280,13 +286,19 @@ fn load_tree_json(tax_json: &Value) -> TaxonomyResult<GeneralTaxonomy> {
         parent_ids: &mut Vec<usize>,
         names: &mut Vec<String>,
         ranks: &mut Vec<TaxRank>,
-        data: &mut Vec<HashMap<String, Value>>,
+        data: &mut Vec<HashMap<String, TaxonomyValue>>,
     ) -> TaxonomyResult<()> {
         tax_ids.push(node.id);
         parent_ids.push(parent_loc);
         names.push(node.name);
         ranks.push(node.rank);
-        data.push(node.extra);
+        // Convert from serde_json::Value to TaxonomyValue
+        data.push(
+            node.extra
+                .into_iter()
+                .map(|(k, v)| (k, TaxonomyValue::from(v)))
+                .collect(),
+        );
         let loc = tax_ids.len() - 1;
         for child in node.children {
             add_node(loc, child, tax_ids, parent_ids, names, ranks, data)?;
@@ -369,78 +381,6 @@ where
     Ok(())
 }
 
-/// Memory-efficient streaming tree export that writes JSON incrementally
-/// instead of building the entire tree structure in memory first.
-pub fn save_tree_streaming<'t, W: Write, T, X: Taxonomy<'t, T>>(
-    mut writer: W,
-    taxonomy: &'t X,
-    root_node: Option<T>,
-) -> TaxonomyResult<()>
-where
-    T: 't + Clone + Debug + Display + Eq + Hash + PartialEq,
-{
-    let tax_id = root_node
-        .or_else(|| {
-            if taxonomy.is_empty() {
-                None
-            } else {
-                Some(taxonomy.root())
-            }
-        })
-        .ok_or(Error::new(ErrorKind::InvalidTaxonomy(
-            "Taxonomy must have a root node.".to_string(),
-        )))?;
-
-    write_node_streaming(taxonomy, tax_id, &mut writer)?;
-    writer.flush()?;
-    Ok(())
-}
-
-fn write_node_streaming<'t, W: Write, T>(
-    tax: &'t impl Taxonomy<'t, T>,
-    tax_id: T,
-    writer: &mut W,
-) -> TaxonomyResult<()>
-where
-    T: 't + Clone + Debug + Display + Eq + Hash + PartialEq,
-{
-    write!(writer, "{{")?;
-
-    // Write id
-    write!(writer, "\"id\":")?;
-    to_writer(&mut *writer, &tax_id.to_string())?;
-
-    // Write name
-    write!(writer, ",\"name\":")?;
-    to_writer(&mut *writer, &tax.name(tax_id.clone())?)?;
-
-    // Write rank
-    write!(writer, ",\"rank\":")?;
-    to_writer(&mut *writer, tax.rank(tax_id.clone())?.to_ncbi_rank())?;
-
-    // Write extra data fields
-    let data = tax.data(tax_id.clone())?;
-    for (key, value) in data.iter() {
-        write!(writer, ",{}", serde_json::to_string(key)?)?;
-        write!(writer, ":")?;
-        to_writer(&mut *writer, value)?;
-    }
-
-    // Write children (always include, even if empty, to match regular format)
-    let children = tax.children(tax_id)?;
-    write!(writer, ",\"children\":[")?;
-    for (i, child) in children.into_iter().enumerate() {
-        if i > 0 {
-            write!(writer, ",")?;
-        }
-        write_node_streaming(tax, child, writer)?;
-    }
-    write!(writer, "]")?;
-
-    write!(writer, "}}")?;
-    Ok(())
-}
-
 fn serialize_as_tree<'t, T: 't>(
     taxonomy: &'t impl Taxonomy<'t, T>,
     root_node: Option<T>,
@@ -460,12 +400,19 @@ where
         for child in tax.children(tax_id.clone())? {
             children.push(inner(tax, child)?);
         }
+        let data = tax.data(tax_id.clone())?;
+        // Convert TaxonomyValue to serde_json::Value
+        let extra: HashMap<String, Value> = data
+            .iter()
+            .map(|(k, v)| (k.clone(), v.into()))
+            .collect();
+
         let node = TaxNodeTree {
             id: tax_id.to_string(),
             name: tax.name(tax_id.clone())?.to_string(),
             rank: tax.rank(tax_id.clone())?,
             children,
-            extra: (*tax.data(tax_id)?).clone(),
+            extra,
         };
         Ok(node)
     }
@@ -486,11 +433,18 @@ where
 
     if let Some(root_id) = root_node {
         for (ix, (tid, _pre)) in tax.traverse(root_id)?.filter(|x| x.1).enumerate() {
+            let data = tax.data(tid.clone())?;
+            // Convert TaxonomyValue to serde_json::Value
+            let extra: HashMap<String, Value> = data
+                .iter()
+                .map(|(k, v)| (k.clone(), v.into()))
+                .collect();
+
             let node = TaxNode {
                 id: tid.to_string(),
                 name: tax.name(tid.clone())?.to_string(),
                 rank: tax.rank(tid.clone())?,
-                extra: (*tax.data(tid.clone())?).clone(),
+                extra,
             };
             nodes.push(to_value(&node).unwrap());
             id_to_idx.insert(tid.clone(), ix);
@@ -791,117 +745,5 @@ mod tests {
     fn can_handle_null_ranks() {
         let example = r#"{"id": "1", "rank": null, "name": ""}"#;
         assert!(load(Cursor::new(example), None).is_ok());
-    }
-
-    #[test]
-    fn streaming_tree_matches_regular_tree() {
-        // Create a taxonomy with multiple nodes and extra data
-        let example = r#"{
-            "id": "1",
-            "name": "root",
-            "rank": "no rank",
-            "custom_field": "value1",
-            "children": [
-                {
-                    "id": "2",
-                    "name": "Bacteria",
-                    "rank": "superkingdom",
-                    "genetic_code_id": "11",
-                    "children": [
-                        {
-                            "id": "562",
-                            "name": "Escherichia coli",
-                            "rank": "species",
-                            "genetic_code_id": "11",
-                            "embl_code": "EC",
-                            "division_id": "0",
-                            "name_common_name": "E. coli"
-                        }
-                    ]
-                }
-            ]
-        }"#;
-
-        let tax = load(Cursor::new(example), None).unwrap();
-
-        // Save using regular method
-        let mut regular_output = Vec::new();
-        save::<_, &str, _>(&mut regular_output, &tax, JsonFormat::Tree, None).unwrap();
-
-        // Save using streaming method
-        let mut streaming_output = Vec::new();
-        save_tree_streaming::<_, &str, _>(&mut streaming_output, &tax, None).unwrap();
-
-        // Parse both outputs
-        let regular_json: Value = serde_json::from_slice(&regular_output).unwrap();
-        let streaming_json: Value = serde_json::from_slice(&streaming_output).unwrap();
-
-        // They should be equivalent
-        assert_eq!(regular_json, streaming_json);
-
-        // Verify we can reload from streaming output
-        let tax2 = load(Cursor::new(&streaming_output[..]), None).unwrap();
-        assert_eq!(Taxonomy::<&str>::len(&tax2), 3);
-        assert_eq!(
-            Taxonomy::<&str>::name(&tax2, "562").unwrap(),
-            "Escherichia coli"
-        );
-
-        // Verify extra data is preserved
-        let data = Taxonomy::<&str>::data(&tax2, "562").unwrap();
-        assert_eq!(
-            data.get("genetic_code_id").and_then(|v| v.as_str()),
-            Some("11")
-        );
-        assert_eq!(data.get("embl_code").and_then(|v| v.as_str()), Some("EC"));
-        assert_eq!(
-            data.get("name_common_name").and_then(|v| v.as_str()),
-            Some("E. coli")
-        );
-    }
-
-    #[test]
-    fn streaming_handles_large_data_fields() {
-        // Test that streaming handles nodes with lots of extra fields (like NCBI data)
-        let example = r#"{
-            "id": "562",
-            "name": "Escherichia coli",
-            "rank": "species",
-            "genetic_code_id": "11",
-            "division_id": "0",
-            "inherited_div_flag": "1",
-            "mitochondrial_genetic_code_id": "0",
-            "inherited_MGC_flag": "1",
-            "GenBank_hidden_flag": "0",
-            "hidden_subtree_root_flag": "0",
-            "comments": "",
-            "name_scientific_name": "Escherichia coli",
-            "name_common_name": "E. coli",
-            "name_synonym": "Bacterium coli",
-            "name_authority": "Escherichia coli (Migula 1895) Castellani and Chalmers 1919"
-        }"#;
-
-        let tax = load(Cursor::new(example), None).unwrap();
-
-        let mut streaming_output = Vec::new();
-        save_tree_streaming::<_, &str, _>(&mut streaming_output, &tax, None).unwrap();
-
-        // Reload and verify all fields preserved
-        let tax2 = load(Cursor::new(&streaming_output[..]), None).unwrap();
-        let data = Taxonomy::<&str>::data(&tax2, "562").unwrap();
-
-        assert_eq!(
-            data.get("genetic_code_id").and_then(|v| v.as_str()),
-            Some("11")
-        );
-        assert_eq!(
-            data.get("name_common_name").and_then(|v| v.as_str()),
-            Some("E. coli")
-        );
-        assert_eq!(
-            data.get("name_synonym").and_then(|v| v.as_str()),
-            Some("Bacterium coli")
-        );
-        assert_eq!(data.get("comments").and_then(|v| v.as_str()), Some(""));
     }
 }

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -86,8 +86,8 @@ pub enum JsonFormat {
     /// 1. the nodes with their taxonomic info. Internal (integer) IDs are the node's position in
     ///    the nodes array
     /// 2. the links between each node: a `source` node has a `parent` node.
-    /// The nodes are represented by indices in the nodes array
-    /// Only use that format if you have existing taxonomies in that format.
+    ///    The nodes are represented by indices in the nodes array
+    ///    Only use that format if you have existing taxonomies in that format.
     NodeLink,
     /// The preferred format
     Tree,

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -402,10 +402,8 @@ where
         }
         let data = tax.data(tax_id.clone())?;
         // Convert TaxonomyValue to serde_json::Value
-        let extra: HashMap<String, Value> = data
-            .iter()
-            .map(|(k, v)| (k.clone(), v.into()))
-            .collect();
+        let extra: HashMap<String, Value> =
+            data.iter().map(|(k, v)| (k.clone(), v.into())).collect();
 
         let node = TaxNodeTree {
             id: tax_id.to_string(),
@@ -435,10 +433,8 @@ where
         for (ix, (tid, _pre)) in tax.traverse(root_id)?.filter(|x| x.1).enumerate() {
             let data = tax.data(tid.clone())?;
             // Convert TaxonomyValue to serde_json::Value
-            let extra: HashMap<String, Value> = data
-                .iter()
-                .map(|(k, v)| (k.clone(), v.into()))
-                .collect();
+            let extra: HashMap<String, Value> =
+                data.iter().map(|(k, v)| (k.clone(), v.into())).collect();
 
             let node = TaxNode {
                 id: tid.to_string(),

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -344,14 +344,14 @@ pub fn load<R: Read>(reader: R, json_pointer: Option<&str>) -> TaxonomyResult<Ge
     Ok(gt)
 }
 
-pub fn save<'t, W: Write, T: 't, X: Taxonomy<'t, T>>(
+pub fn save<'t, W: Write, T, X: Taxonomy<'t, T>>(
     writer: W,
     taxonomy: &'t X,
     format: JsonFormat,
     root_node: Option<T>,
 ) -> TaxonomyResult<()>
 where
-    T: Clone + Debug + Display + Eq + Hash + PartialEq,
+    T: 't + Clone + Debug + Display + Eq + Hash + PartialEq,
 {
     // Defaults to root but root exists only if taxonomy is not empty.
     let root_node = root_node.or(if taxonomy.is_empty() {
@@ -371,13 +371,13 @@ where
 
 /// Memory-efficient streaming tree export that writes JSON incrementally
 /// instead of building the entire tree structure in memory first.
-pub fn save_tree_streaming<'t, W: Write, T: 't, X: Taxonomy<'t, T>>(
+pub fn save_tree_streaming<'t, W: Write, T, X: Taxonomy<'t, T>>(
     mut writer: W,
     taxonomy: &'t X,
     root_node: Option<T>,
 ) -> TaxonomyResult<()>
 where
-    T: Clone + Debug + Display + Eq + Hash + PartialEq,
+    T: 't + Clone + Debug + Display + Eq + Hash + PartialEq,
 {
     let tax_id = root_node
         .or_else(|| {
@@ -396,13 +396,13 @@ where
     Ok(())
 }
 
-fn write_node_streaming<'t, W: Write, T: 't>(
+fn write_node_streaming<'t, W: Write, T>(
     tax: &'t impl Taxonomy<'t, T>,
     tax_id: T,
     writer: &mut W,
 ) -> TaxonomyResult<()>
 where
-    T: Clone + Debug + Display + Eq + Hash + PartialEq,
+    T: 't + Clone + Debug + Display + Eq + Hash + PartialEq,
 {
     write!(writer, "{{")?;
 
@@ -452,9 +452,9 @@ where
         "Taxonomy must have a root node.".to_string(),
     )))?;
 
-    fn inner<'t, T: 't>(tax: &'t impl Taxonomy<'t, T>, tax_id: T) -> TaxonomyResult<TaxNodeTree>
+    fn inner<'t, T>(tax: &'t impl Taxonomy<'t, T>, tax_id: T) -> TaxonomyResult<TaxNodeTree>
     where
-        T: Clone + Debug + Display + Eq + Hash + PartialEq,
+        T: 't + Clone + Debug + Display + Eq + Hash + PartialEq,
     {
         let mut children = Vec::new();
         for child in tax.children(tax_id.clone())? {
@@ -473,12 +473,12 @@ where
     Ok(to_value(inner(taxonomy, tax_id)?)?)
 }
 
-fn serialize_as_node_links<'t, T: 't>(
+fn serialize_as_node_links<'t, T>(
     tax: &'t impl Taxonomy<'t, T>,
     root_node: Option<T>,
 ) -> TaxonomyResult<Value>
 where
-    T: Clone + Debug + Display + Eq + Hash + PartialEq,
+    T: 't + Clone + Debug + Display + Eq + Hash + PartialEq,
 {
     let mut nodes = Vec::new();
     let mut links = Vec::new();

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -381,12 +381,12 @@ where
     Ok(())
 }
 
-fn serialize_as_tree<'t, T: 't>(
+fn serialize_as_tree<'t, T>(
     taxonomy: &'t impl Taxonomy<'t, T>,
     root_node: Option<T>,
 ) -> TaxonomyResult<Value>
 where
-    T: Clone + Debug + Display + Eq + Hash + PartialEq,
+    T: 't + Clone + Debug + Display + Eq + Hash + PartialEq,
 {
     let tax_id = root_node.ok_or(Error::new(ErrorKind::InvalidTaxonomy(
         "Taxonomy must have a root node.".to_string(),

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -47,7 +47,12 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         let GenBank_hidden_flag = fields.remove(0).trim().to_string();
         let hidden_subtree_root_flag = fields.remove(0).trim().to_string();
         let comments = if !fields.is_empty() {
-            fields.remove(0).trim().trim_end_matches('|').trim().to_string()
+            fields
+                .remove(0)
+                .trim()
+                .trim_end_matches('|')
+                .trim()
+                .to_string()
         } else {
             String::new()
         };
@@ -59,31 +64,58 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         // Store all node fields in data HashMap
         let mut node_data = HashMap::new();
         if !embl_code.is_empty() {
-            node_data.insert("embl_code".to_string(), serde_json::Value::String(embl_code));
+            node_data.insert(
+                "embl_code".to_string(),
+                serde_json::Value::String(embl_code),
+            );
         }
         if !division_id.is_empty() {
-            node_data.insert("division_id".to_string(), serde_json::Value::String(division_id));
+            node_data.insert(
+                "division_id".to_string(),
+                serde_json::Value::String(division_id),
+            );
         }
         if !inherited_div_flag.is_empty() {
-            node_data.insert("inherited_div_flag".to_string(), serde_json::Value::String(inherited_div_flag));
+            node_data.insert(
+                "inherited_div_flag".to_string(),
+                serde_json::Value::String(inherited_div_flag),
+            );
         }
         if !genetic_code_id.is_empty() {
-            node_data.insert("genetic_code_id".to_string(), serde_json::Value::String(genetic_code_id));
+            node_data.insert(
+                "genetic_code_id".to_string(),
+                serde_json::Value::String(genetic_code_id),
+            );
         }
         if !inherited_GC_flag.is_empty() {
-            node_data.insert("inherited_GC_flag".to_string(), serde_json::Value::String(inherited_GC_flag));
+            node_data.insert(
+                "inherited_GC_flag".to_string(),
+                serde_json::Value::String(inherited_GC_flag),
+            );
         }
         if !mitochondrial_genetic_code_id.is_empty() {
-            node_data.insert("mitochondrial_genetic_code_id".to_string(), serde_json::Value::String(mitochondrial_genetic_code_id));
+            node_data.insert(
+                "mitochondrial_genetic_code_id".to_string(),
+                serde_json::Value::String(mitochondrial_genetic_code_id),
+            );
         }
         if !inherited_MGC_flag.is_empty() {
-            node_data.insert("inherited_MGC_flag".to_string(), serde_json::Value::String(inherited_MGC_flag));
+            node_data.insert(
+                "inherited_MGC_flag".to_string(),
+                serde_json::Value::String(inherited_MGC_flag),
+            );
         }
         if !GenBank_hidden_flag.is_empty() {
-            node_data.insert("GenBank_hidden_flag".to_string(), serde_json::Value::String(GenBank_hidden_flag));
+            node_data.insert(
+                "GenBank_hidden_flag".to_string(),
+                serde_json::Value::String(GenBank_hidden_flag),
+            );
         }
         if !hidden_subtree_root_flag.is_empty() {
-            node_data.insert("hidden_subtree_root_flag".to_string(), serde_json::Value::String(hidden_subtree_root_flag));
+            node_data.insert(
+                "hidden_subtree_root_flag".to_string(),
+                serde_json::Value::String(hidden_subtree_root_flag),
+            );
         }
         if !comments.is_empty() {
             node_data.insert("comments".to_string(), serde_json::Value::String(comments));
@@ -119,7 +151,12 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         let tax_id = fields.remove(0).trim().to_string();
         let name_txt = fields.remove(0).trim().to_string();
         let unique_name = fields.remove(0).trim().to_string();
-        let name_class = fields.remove(0).trim().trim_end_matches('|').trim().to_string();
+        let name_class = fields
+            .remove(0)
+            .trim()
+            .trim_end_matches('|')
+            .trim()
+            .to_string();
 
         if let Some(&idx) = tax_to_idx.get(&tax_id) {
             if name_class == "scientific name" {
@@ -258,19 +295,32 @@ where
             .unwrap_or("");
 
         // Write scientific name
-        write_names_row(&mut name_writer, &format!("{}", &key), &name, "", "scientific name")?;
+        write_names_row(
+            &mut name_writer,
+            &format!("{}", &key),
+            &name,
+            "",
+            "scientific name",
+        )?;
 
         // Write all alternative names from data
         for (data_key, value) in node_data.iter() {
             if data_key.starts_with("name_") && data_key != "name_scientific_name" {
                 let name_class = data_key.strip_prefix("name_").unwrap().replace("_", " ");
                 let name_txt = value.as_str().unwrap_or("");
-                let unique_name_key = format!("unique_name_{}", data_key.strip_prefix("name_").unwrap());
+                let unique_name_key =
+                    format!("unique_name_{}", data_key.strip_prefix("name_").unwrap());
                 let unique_name = node_data
                     .get(&unique_name_key)
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
-                write_names_row(&mut name_writer, &format!("{}", &key), name_txt, unique_name, &name_class)?;
+                write_names_row(
+                    &mut name_writer,
+                    &format!("{}", &key),
+                    name_txt,
+                    unique_name,
+                    &name_class,
+                )?;
             }
         }
 
@@ -450,14 +500,18 @@ mod tests {
         // Check that data fields are preserved through save/load cycle
         let data_562_after = Taxonomy::<&str>::data(&tax2, "562").unwrap();
         assert_eq!(
-            data_562_after.get("genetic_code_id").and_then(|v| v.as_str()),
+            data_562_after
+                .get("genetic_code_id")
+                .and_then(|v| v.as_str()),
             Some("11")
         );
 
         // Check that alternative names are preserved
         assert!(data_562_after.contains_key("name_common_name"));
         assert_eq!(
-            data_562_after.get("name_common_name").and_then(|v| v.as_str()),
+            data_562_after
+                .get("name_common_name")
+                .and_then(|v| v.as_str()),
             Some("E. coli")
         );
     }

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -23,12 +23,12 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
     let mut tax_ids: Vec<String> = Vec::new();
     let mut parents: Vec<String> = Vec::new();
     let mut ranks: Vec<TaxRank> = Vec::new();
+    let mut data: Vec<HashMap<String, serde_json::Value>> = Vec::new();
     let mut tax_to_idx: HashMap<String, usize> = HashMap::new();
 
     for (ix, line) in BufReader::new(nodes_file).lines().enumerate() {
         let mut fields: Vec<String> = line?.split("\t|\t").map(|x| x.to_string()).collect();
-        if fields.len() < 10 {
-            // should be at least 14
+        if fields.len() < 12 {
             return Err(Error::new(ErrorKind::ImportError {
                 line: ix,
                 msg: "Not enough fields in nodes.dmp; bad line?".to_owned(),
@@ -36,11 +36,60 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         }
         let tax_id = fields.remove(0).trim().to_string();
         let parent_tax_id = fields.remove(0).trim().to_string();
-        let rank = fields.remove(0);
+        let rank = fields.remove(0).trim().to_string();
+        let embl_code = fields.remove(0).trim().to_string();
+        let division_id = fields.remove(0).trim().to_string();
+        let inherited_div_flag = fields.remove(0).trim().to_string();
+        let genetic_code_id = fields.remove(0).trim().to_string();
+        let inherited_GC_flag = fields.remove(0).trim().to_string();
+        let mitochondrial_genetic_code_id = fields.remove(0).trim().to_string();
+        let inherited_MGC_flag = fields.remove(0).trim().to_string();
+        let GenBank_hidden_flag = fields.remove(0).trim().to_string();
+        let hidden_subtree_root_flag = fields.remove(0).trim().to_string();
+        let comments = if !fields.is_empty() {
+            fields.remove(0).trim().trim_end_matches("\t|").to_string()
+        } else {
+            String::new()
+        };
 
         tax_ids.push(tax_id.clone());
         parents.push(parent_tax_id.to_string());
         ranks.push(TaxRank::from_str(&rank)?);
+
+        // Store all node fields in data HashMap
+        let mut node_data = HashMap::new();
+        if !embl_code.is_empty() {
+            node_data.insert("embl_code".to_string(), serde_json::Value::String(embl_code));
+        }
+        if !division_id.is_empty() {
+            node_data.insert("division_id".to_string(), serde_json::Value::String(division_id));
+        }
+        if !inherited_div_flag.is_empty() {
+            node_data.insert("inherited_div_flag".to_string(), serde_json::Value::String(inherited_div_flag));
+        }
+        if !genetic_code_id.is_empty() {
+            node_data.insert("genetic_code_id".to_string(), serde_json::Value::String(genetic_code_id));
+        }
+        if !inherited_GC_flag.is_empty() {
+            node_data.insert("inherited_GC_flag".to_string(), serde_json::Value::String(inherited_GC_flag));
+        }
+        if !mitochondrial_genetic_code_id.is_empty() {
+            node_data.insert("mitochondrial_genetic_code_id".to_string(), serde_json::Value::String(mitochondrial_genetic_code_id));
+        }
+        if !inherited_MGC_flag.is_empty() {
+            node_data.insert("inherited_MGC_flag".to_string(), serde_json::Value::String(inherited_MGC_flag));
+        }
+        if !GenBank_hidden_flag.is_empty() {
+            node_data.insert("GenBank_hidden_flag".to_string(), serde_json::Value::String(GenBank_hidden_flag));
+        }
+        if !hidden_subtree_root_flag.is_empty() {
+            node_data.insert("hidden_subtree_root_flag".to_string(), serde_json::Value::String(hidden_subtree_root_flag));
+        }
+        if !comments.is_empty() {
+            node_data.insert("comments".to_string(), serde_json::Value::String(comments));
+        }
+
+        data.push(node_data);
         tax_to_idx.insert(tax_id, ix);
     }
 
@@ -57,28 +106,45 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         }
     }
 
-    // And then grab their names by their idx
+    // Grab scientific names and store all other name types in data
     let mut names: Vec<String> = vec![String::new(); tax_ids.len()];
     for (ix, line) in BufReader::new(names_file).lines().enumerate() {
         let mut fields: Vec<String> = line?.split("\t|\t").map(|x| x.to_string()).collect();
-        if fields.len() > 10 {
-            // should only be 5
+        if fields.len() < 4 {
             return Err(Error::new(ErrorKind::ImportError {
                 line: ix,
-                msg: "Too many fields in names.dmp".to_owned(),
+                msg: "Not enough fields in names.dmp".to_owned(),
             }));
         }
         let tax_id = fields.remove(0).trim().to_string();
-        let name = fields.remove(0).trim().to_string();
-        let name_class = fields.remove(1);
-        if name_class.starts_with("scientific name") {
-            let name = name.to_string();
-            names[tax_to_idx[&*tax_id]] = name;
+        let name_txt = fields.remove(0).trim().to_string();
+        let unique_name = fields.remove(0).trim().to_string();
+        let name_class = fields.remove(0).trim().trim_end_matches("\t|").to_string();
+
+        if let Some(&idx) = tax_to_idx.get(&tax_id) {
+            if name_class == "scientific name" {
+                names[idx] = name_txt.clone();
+            }
+
+            // Store all name types in data
+            let name_key = format!("name_{}", name_class.replace(" ", "_"));
+            data[idx].insert(name_key, serde_json::Value::String(name_txt));
+
+            if !unique_name.is_empty() {
+                let unique_key = format!("unique_name_{}", name_class.replace(" ", "_"));
+                data[idx].insert(unique_key, serde_json::Value::String(unique_name));
+            }
         }
     }
 
-    let gt =
-        GeneralTaxonomy::from_arrays(tax_ids, parent_ids, Some(names), Some(ranks), None, None)?;
+    let gt = GeneralTaxonomy::from_arrays(
+        tax_ids,
+        parent_ids,
+        Some(names),
+        Some(ranks),
+        None,
+        Some(data),
+    )?;
     gt.validate_uniqueness()?;
     Ok(gt)
 }
@@ -106,14 +172,88 @@ where
                 .map(|(x, _)| format!("{}", x))
                 .unwrap_or_default()
         };
+
+        // Extract data fields
+        let node_data = tax.data(key.clone())?;
+        let embl_code = node_data
+            .get("embl_code")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let division_id = node_data
+            .get("division_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("0");
+        let inherited_div_flag = node_data
+            .get("inherited_div_flag")
+            .and_then(|v| v.as_str())
+            .unwrap_or("0");
+        let genetic_code_id = node_data
+            .get("genetic_code_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("1");
+        let inherited_GC_flag = node_data
+            .get("inherited_GC_flag")
+            .and_then(|v| v.as_str())
+            .unwrap_or("0");
+        let mitochondrial_genetic_code_id = node_data
+            .get("mitochondrial_genetic_code_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("0");
+        let inherited_MGC_flag = node_data
+            .get("inherited_MGC_flag")
+            .and_then(|v| v.as_str())
+            .unwrap_or("0");
+        let GenBank_hidden_flag = node_data
+            .get("GenBank_hidden_flag")
+            .and_then(|v| v.as_str())
+            .unwrap_or("0");
+        let hidden_subtree_root_flag = node_data
+            .get("hidden_subtree_root_flag")
+            .and_then(|v| v.as_str())
+            .unwrap_or("0");
+        let comments = node_data
+            .get("comments")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        // Write scientific name
         name_writer
             .write_all(format!("{}\t|\t{}\t|\t\t|\tscientific name\t|\n", &key, name).as_bytes())?;
+
+        // Write all alternative names from data
+        for (data_key, value) in node_data.iter() {
+            if data_key.starts_with("name_") && data_key != "name_scientific_name" {
+                let name_class = data_key.strip_prefix("name_").unwrap().replace("_", " ");
+                let name_txt = value.as_str().unwrap_or("");
+                let unique_name_key = format!("unique_name_{}", data_key.strip_prefix("name_").unwrap());
+                let unique_name = node_data
+                    .get(&unique_name_key)
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                name_writer.write_all(
+                    format!("{}\t|\t{}\t|\t{}\t|\t{}\t|\n", &key, name_txt, unique_name, name_class)
+                        .as_bytes(),
+                )?;
+            }
+        }
+
+        // Write nodes.dmp entry with all fields
         node_writer.write_all(
             format!(
-                "{}\t|\t{}\t|\t{}\t|\t\t|\t\t|\t\t|\t\t|\t\t|\t\t|\t\t|\t\t|\t\t|\t\t|\n",
+                "{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\n",
                 &key,
                 parent,
                 rank.to_ncbi_rank(),
+                embl_code,
+                division_id,
+                inherited_div_flag,
+                genetic_code_id,
+                inherited_GC_flag,
+                mitochondrial_genetic_code_id,
+                inherited_MGC_flag,
+                GenBank_hidden_flag,
+                hidden_subtree_root_flag,
+                comments,
             )
             .as_bytes(),
         )?;
@@ -219,6 +359,20 @@ mod tests {
             Some(("561", 1.))
         );
 
+        // Check that node data fields are loaded
+        let data_562 = Taxonomy::<&str>::data(&tax, "562").unwrap();
+        assert_eq!(
+            data_562.get("genetic_code_id").and_then(|v| v.as_str()),
+            Some("11")
+        );
+
+        // Check that alternative names are stored
+        assert!(data_562.contains_key("name_common_name"));
+        assert_eq!(
+            data_562.get("name_common_name").and_then(|v| v.as_str()),
+            Some("E. coli")
+        );
+
         let out = path.join("out");
         save::<&str, _, _>(&tax, &out).unwrap();
 
@@ -257,6 +411,20 @@ mod tests {
         assert_eq!(
             Taxonomy::<&str>::children(&tax2, "561").unwrap(),
             vec!["562"]
+        );
+
+        // Check that data fields are preserved through save/load cycle
+        let data_562_after = Taxonomy::<&str>::data(&tax2, "562").unwrap();
+        assert_eq!(
+            data_562_after.get("genetic_code_id").and_then(|v| v.as_str()),
+            Some("11")
+        );
+
+        // Check that alternative names are preserved
+        assert!(data_562_after.contains_key("name_common_name"));
+        assert_eq!(
+            data_562_after.get("name_common_name").and_then(|v| v.as_str()),
+            Some("E. coli")
         );
     }
 }

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -47,7 +47,7 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         let GenBank_hidden_flag = fields.remove(0).trim().to_string();
         let hidden_subtree_root_flag = fields.remove(0).trim().to_string();
         let comments = if !fields.is_empty() {
-            fields.remove(0).trim().trim_end_matches("\t|").to_string()
+            fields.remove(0).trim().trim_end_matches('|').trim().to_string()
         } else {
             String::new()
         };
@@ -119,7 +119,7 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         let tax_id = fields.remove(0).trim().to_string();
         let name_txt = fields.remove(0).trim().to_string();
         let unique_name = fields.remove(0).trim().to_string();
-        let name_class = fields.remove(0).trim().trim_end_matches("\t|").to_string();
+        let name_class = fields.remove(0).trim().trim_end_matches('|').trim().to_string();
 
         if let Some(&idx) = tax_to_idx.get(&tax_id) {
             if name_class == "scientific name" {

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -206,9 +206,19 @@ fn write_nodes_row(
     writeln!(
         writer,
         "{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|",
-        tax_id, parent, rank, embl_code, division_id, inherited_div,
-        genetic_code, inherited_gc, mito_gc, inherited_mgc,
-        genbank_hidden, subtree_hidden, comments
+        tax_id,
+        parent,
+        rank,
+        embl_code,
+        division_id,
+        inherited_div,
+        genetic_code,
+        inherited_gc,
+        mito_gc,
+        inherited_mgc,
+        genbank_hidden,
+        subtree_hidden,
+        comments
     )
 }
 

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -280,12 +280,13 @@ fn write_names_row(
     )
 }
 
-pub fn save<'t, T: 't, P: AsRef<Path>, X: Taxonomy<'t, T>>(
+pub fn save<'t, T, P: AsRef<Path>, X: Taxonomy<'t, T>>(
     tax: &'t X,
     out_dir: P,
+    include_extended: bool,
 ) -> TaxonomyResult<()>
 where
-    T: Clone + Debug + Display + PartialEq,
+    T: 't + Clone + Debug + Display + PartialEq,
 {
     let dir = out_dir.as_ref();
     std::fs::create_dir_all(dir)?;
@@ -306,54 +307,69 @@ where
 
         // Extract data fields with proper types
         let node_data = tax.data(key.clone())?;
-        let embl_code = node_data
-            .get("embl_code")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
-        let division_id = node_data
-            .get("division_id")
-            .and_then(|v| v.as_i64())
-            .map(|i| i.to_string())
-            .unwrap_or_else(|| "".to_string());
-        let inherited_div_flag = node_data
-            .get("inherited_div_flag")
-            .and_then(|v| v.as_bool())
-            .map(|b| if b { "1" } else { "0" })
-            .unwrap_or("");
-        let genetic_code_id = node_data
-            .get("genetic_code_id")
-            .and_then(|v| v.as_i64())
-            .map(|i| i.to_string())
-            .unwrap_or_else(|| "".to_string());
-        let inherited_gc_flag = node_data
-            .get("inherited_gc_flag")
-            .and_then(|v| v.as_bool())
-            .map(|b| if b { "1" } else { "0" })
-            .unwrap_or("");
-        let mitochondrial_genetic_code_id = node_data
-            .get("mitochondrial_genetic_code_id")
-            .and_then(|v| v.as_i64())
-            .map(|i| i.to_string())
-            .unwrap_or_else(|| "".to_string());
-        let inherited_mgc_flag = node_data
-            .get("inherited_mgc_flag")
-            .and_then(|v| v.as_bool())
-            .map(|b| if b { "1" } else { "0" })
-            .unwrap_or("");
-        let genbank_hidden_flag = node_data
-            .get("genbank_hidden_flag")
-            .and_then(|v| v.as_bool())
-            .map(|b| if b { "1" } else { "0" })
-            .unwrap_or("");
-        let hidden_subtree_root_flag = node_data
-            .get("hidden_subtree_root_flag")
-            .and_then(|v| v.as_bool())
-            .map(|b| if b { "1" } else { "0" })
-            .unwrap_or("");
-        let comments = node_data
-            .get("comments")
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+
+        let (embl_code, division_id, inherited_div_flag, genetic_code_id,
+             inherited_gc_flag, mitochondrial_genetic_code_id, inherited_mgc_flag,
+             genbank_hidden_flag, hidden_subtree_root_flag, comments) = if include_extended {
+            // Extract extended fields from data
+            let embl_code = node_data
+                .get("embl_code")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let division_id = node_data
+                .get("division_id")
+                .and_then(|v| v.as_i64())
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| "".to_string());
+            let inherited_div_flag = node_data
+                .get("inherited_div_flag")
+                .and_then(|v| v.as_bool())
+                .map(|b| if b { "1" } else { "0" })
+                .unwrap_or("");
+            let genetic_code_id = node_data
+                .get("genetic_code_id")
+                .and_then(|v| v.as_i64())
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| "".to_string());
+            let inherited_gc_flag = node_data
+                .get("inherited_gc_flag")
+                .and_then(|v| v.as_bool())
+                .map(|b| if b { "1" } else { "0" })
+                .unwrap_or("");
+            let mitochondrial_genetic_code_id = node_data
+                .get("mitochondrial_genetic_code_id")
+                .and_then(|v| v.as_i64())
+                .map(|i| i.to_string())
+                .unwrap_or_else(|| "".to_string());
+            let inherited_mgc_flag = node_data
+                .get("inherited_mgc_flag")
+                .and_then(|v| v.as_bool())
+                .map(|b| if b { "1" } else { "0" })
+                .unwrap_or("");
+            let genbank_hidden_flag = node_data
+                .get("genbank_hidden_flag")
+                .and_then(|v| v.as_bool())
+                .map(|b| if b { "1" } else { "0" })
+                .unwrap_or("");
+            let hidden_subtree_root_flag = node_data
+                .get("hidden_subtree_root_flag")
+                .and_then(|v| v.as_bool())
+                .map(|b| if b { "1" } else { "0" })
+                .unwrap_or("");
+            let comments = node_data
+                .get("comments")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+
+            (embl_code, division_id, inherited_div_flag, genetic_code_id,
+             inherited_gc_flag, mitochondrial_genetic_code_id, inherited_mgc_flag,
+             genbank_hidden_flag, hidden_subtree_root_flag, comments)
+        } else {
+            // Use empty/default values for backwards compatibility
+            ("", "".to_string(), "", "".to_string(),
+             "", "".to_string(), "",
+             "", "", "")
+        };
 
         // Write scientific name
         write_names_row(
@@ -364,20 +380,22 @@ where
             "scientific name",
         )?;
 
-        // Write all alternative names from data
-        if let Some(names_value) = node_data.get("names") {
-            if let Some(names_array) = names_value.as_array() {
-                for name_value in names_array {
-                    if let Some(tax_name) = TaxonomyName::from_taxonomy_value(name_value) {
-                        // Skip scientific name as it's already written above
-                        if tax_name.name_class != "scientific name" {
-                            write_names_row(
-                                &mut name_writer,
-                                &format!("{}", &key),
-                                &tax_name.name_text,
-                                tax_name.unique_name.as_deref().unwrap_or(""),
-                                &tax_name.name_class,
-                            )?;
+        // Write all alternative names from data (only if extended fields are included)
+        if include_extended {
+            if let Some(names_value) = node_data.get("names") {
+                if let Some(names_array) = names_value.as_array() {
+                    for name_value in names_array {
+                        if let Some(tax_name) = TaxonomyName::from_taxonomy_value(name_value) {
+                            // Skip scientific name as it's already written above
+                            if tax_name.name_class != "scientific name" {
+                                write_names_row(
+                                    &mut name_writer,
+                                    &format!("{}", &key),
+                                    &tax_name.name_text,
+                                    tax_name.unique_name.as_deref().unwrap_or(""),
+                                    &tax_name.name_class,
+                                )?;
+                            }
                         }
                     }
                 }
@@ -537,7 +555,7 @@ mod tests {
         assert_eq!(common_name, "E. coli");
 
         let out = path.join("out");
-        save::<&str, _, _>(&tax, &out).unwrap();
+        save::<&str, _, _>(&tax, &out, true).unwrap();
 
         // now load again and validate a few taxids
         let tax2 = load(&out).unwrap();

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -12,6 +12,23 @@ use crate::taxonomy::Taxonomy;
 const NODES_FILENAME: &str = "nodes.dmp";
 const NAMES_FILENAME: &str = "names.dmp";
 
+/// Data for a single row in nodes.dmp
+struct NodesRow<'a> {
+    tax_id: &'a str,
+    parent: &'a str,
+    rank: &'a str,
+    embl_code: &'a str,
+    division_id: &'a str,
+    inherited_div: &'a str,
+    genetic_code: &'a str,
+    inherited_gc: &'a str,
+    mito_gc: &'a str,
+    inherited_mgc: &'a str,
+    genbank_hidden: &'a str,
+    subtree_hidden: &'a str,
+    comments: &'a str,
+}
+
 /// Loads a NCBI taxonomy from the given directory.
 /// The directory should contain at least two files: `nodes.dmp` and `names.dmp`.
 pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy> {
@@ -189,36 +206,24 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
 /// Helper function to write a single row to nodes.dmp
 fn write_nodes_row(
     writer: &mut BufWriter<std::fs::File>,
-    tax_id: &str,
-    parent: &str,
-    rank: &str,
-    embl_code: &str,
-    division_id: &str,
-    inherited_div: &str,
-    genetic_code: &str,
-    inherited_gc: &str,
-    mito_gc: &str,
-    inherited_mgc: &str,
-    genbank_hidden: &str,
-    subtree_hidden: &str,
-    comments: &str,
+    row: &NodesRow,
 ) -> std::io::Result<()> {
     writeln!(
         writer,
         "{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|",
-        tax_id,
-        parent,
-        rank,
-        embl_code,
-        division_id,
-        inherited_div,
-        genetic_code,
-        inherited_gc,
-        mito_gc,
-        inherited_mgc,
-        genbank_hidden,
-        subtree_hidden,
-        comments
+        row.tax_id,
+        row.parent,
+        row.rank,
+        row.embl_code,
+        row.division_id,
+        row.inherited_div,
+        row.genetic_code,
+        row.inherited_gc,
+        row.mito_gc,
+        row.inherited_mgc,
+        row.genbank_hidden,
+        row.subtree_hidden,
+        row.comments
     )
 }
 
@@ -335,21 +340,24 @@ where
         }
 
         // Write nodes.dmp entry with all fields
+        let tax_id_str = format!("{}", &key);
         write_nodes_row(
             &mut node_writer,
-            &format!("{}", &key),
-            &parent,
-            rank.to_ncbi_rank(),
-            embl_code,
-            division_id,
-            inherited_div_flag,
-            genetic_code_id,
-            inherited_GC_flag,
-            mitochondrial_genetic_code_id,
-            inherited_MGC_flag,
-            GenBank_hidden_flag,
-            hidden_subtree_root_flag,
-            comments,
+            &NodesRow {
+                tax_id: &tax_id_str,
+                parent: &parent,
+                rank: rank.to_ncbi_rank(),
+                embl_code,
+                division_id,
+                inherited_div: inherited_div_flag,
+                genetic_code: genetic_code_id,
+                inherited_gc: inherited_GC_flag,
+                mito_gc: mitochondrial_genetic_code_id,
+                inherited_mgc: inherited_MGC_flag,
+                genbank_hidden: GenBank_hidden_flag,
+                subtree_hidden: hidden_subtree_root_flag,
+                comments,
+            },
         )?;
     }
 

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -4,13 +4,48 @@ use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
 use std::str::FromStr;
 
-use crate::base::GeneralTaxonomy;
+use crate::base::{GeneralTaxonomy, TaxonomyValue};
 use crate::errors::{Error, ErrorKind, TaxonomyResult};
 use crate::rank::TaxRank;
 use crate::taxonomy::Taxonomy;
 
 const NODES_FILENAME: &str = "nodes.dmp";
 const NAMES_FILENAME: &str = "names.dmp";
+
+/// Represents a taxonomic name with its class and optional unique name
+#[derive(Debug, Clone)]
+struct TaxonomyName {
+    name_class: String,
+    name_text: String,
+    unique_name: Option<String>,
+}
+
+impl TaxonomyName {
+    fn to_taxonomy_value(&self) -> TaxonomyValue {
+        let mut map = HashMap::new();
+        map.insert("name_class".to_string(), TaxonomyValue::String(self.name_class.clone()));
+        map.insert("name_text".to_string(), TaxonomyValue::String(self.name_text.clone()));
+        if let Some(ref unique) = self.unique_name {
+            map.insert("unique_name".to_string(), TaxonomyValue::String(unique.clone()));
+        }
+        TaxonomyValue::Object(map)
+    }
+
+    fn from_taxonomy_value(value: &TaxonomyValue) -> Option<Self> {
+        if let TaxonomyValue::Object(map) = value {
+            let name_class = map.get("name_class")?.as_str()?.to_string();
+            let name_text = map.get("name_text")?.as_str()?.to_string();
+            let unique_name = map.get("unique_name").and_then(|v| v.as_str()).map(|s| s.to_string());
+            Some(TaxonomyName {
+                name_class,
+                name_text,
+                unique_name,
+            })
+        } else {
+            None
+        }
+    }
+}
 
 /// Data for a single row in nodes.dmp
 struct NodesRow<'a> {
@@ -53,16 +88,16 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         }
         let tax_id = fields.remove(0).trim().to_string();
         let parent_tax_id = fields.remove(0).trim().to_string();
-        let rank = fields.remove(0).trim().to_string();
-        let embl_code = fields.remove(0).trim().to_string();
-        let division_id = fields.remove(0).trim().to_string();
-        let inherited_div_flag = fields.remove(0).trim().to_string();
-        let genetic_code_id = fields.remove(0).trim().to_string();
-        let inherited_GC_flag = fields.remove(0).trim().to_string();
-        let mitochondrial_genetic_code_id = fields.remove(0).trim().to_string();
-        let inherited_MGC_flag = fields.remove(0).trim().to_string();
-        let GenBank_hidden_flag = fields.remove(0).trim().to_string();
-        let hidden_subtree_root_flag = fields.remove(0).trim().to_string();
+        let rank = TaxRank::from_str(fields.remove(0).trim())?;
+        let embl_code = fields.remove(0).trim();
+        let division_id = fields.remove(0).trim().parse::<i64>().ok();
+        let inherited_div_flag = fields.remove(0).trim() == "1";
+        let genetic_code_id = fields.remove(0).trim().parse::<i64>().ok();
+        let inherited_gc_flag = fields.remove(0).trim() == "1";
+        let mitochondrial_genetic_code_id = fields.remove(0).trim().parse::<i64>().ok();
+        let inherited_mgc_flag = fields.remove(0).trim() == "1";
+        let genbank_hidden_flag = fields.remove(0).trim() == "1";
+        let hidden_subtree_root_flag = fields.remove(0).trim() == "1";
         let comments = if !fields.is_empty() {
             fields
                 .remove(0)
@@ -76,66 +111,50 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
 
         tax_ids.push(tax_id.clone());
         parents.push(parent_tax_id.to_string());
-        ranks.push(TaxRank::from_str(&rank)?);
+        ranks.push(rank);
 
-        // Store all node fields in data HashMap
+        // Store all node fields in data HashMap with proper types
         let mut node_data = HashMap::new();
         if !embl_code.is_empty() {
             node_data.insert(
                 "embl_code".to_string(),
-                serde_json::Value::String(embl_code),
+                TaxonomyValue::String(embl_code.to_string()),
             );
         }
-        if !division_id.is_empty() {
-            node_data.insert(
-                "division_id".to_string(),
-                serde_json::Value::String(division_id),
-            );
+        if let Some(div_id) = division_id {
+            node_data.insert("division_id".to_string(), TaxonomyValue::Integer(div_id));
         }
-        if !inherited_div_flag.is_empty() {
-            node_data.insert(
-                "inherited_div_flag".to_string(),
-                serde_json::Value::String(inherited_div_flag),
-            );
+        node_data.insert(
+            "inherited_div_flag".to_string(),
+            TaxonomyValue::Bool(inherited_div_flag),
+        );
+        if let Some(gc_id) = genetic_code_id {
+            node_data.insert("genetic_code_id".to_string(), TaxonomyValue::Integer(gc_id));
         }
-        if !genetic_code_id.is_empty() {
-            node_data.insert(
-                "genetic_code_id".to_string(),
-                serde_json::Value::String(genetic_code_id),
-            );
-        }
-        if !inherited_GC_flag.is_empty() {
-            node_data.insert(
-                "inherited_GC_flag".to_string(),
-                serde_json::Value::String(inherited_GC_flag),
-            );
-        }
-        if !mitochondrial_genetic_code_id.is_empty() {
+        node_data.insert(
+            "inherited_gc_flag".to_string(),
+            TaxonomyValue::Bool(inherited_gc_flag),
+        );
+        if let Some(mgc_id) = mitochondrial_genetic_code_id {
             node_data.insert(
                 "mitochondrial_genetic_code_id".to_string(),
-                serde_json::Value::String(mitochondrial_genetic_code_id),
+                TaxonomyValue::Integer(mgc_id),
             );
         }
-        if !inherited_MGC_flag.is_empty() {
-            node_data.insert(
-                "inherited_MGC_flag".to_string(),
-                serde_json::Value::String(inherited_MGC_flag),
-            );
-        }
-        if !GenBank_hidden_flag.is_empty() {
-            node_data.insert(
-                "GenBank_hidden_flag".to_string(),
-                serde_json::Value::String(GenBank_hidden_flag),
-            );
-        }
-        if !hidden_subtree_root_flag.is_empty() {
-            node_data.insert(
-                "hidden_subtree_root_flag".to_string(),
-                serde_json::Value::String(hidden_subtree_root_flag),
-            );
-        }
+        node_data.insert(
+            "inherited_mgc_flag".to_string(),
+            TaxonomyValue::Bool(inherited_mgc_flag),
+        );
+        node_data.insert(
+            "genbank_hidden_flag".to_string(),
+            TaxonomyValue::Bool(genbank_hidden_flag),
+        );
+        node_data.insert(
+            "hidden_subtree_root_flag".to_string(),
+            TaxonomyValue::Bool(hidden_subtree_root_flag),
+        );
         if !comments.is_empty() {
-            node_data.insert("comments".to_string(), serde_json::Value::String(comments));
+            node_data.insert("comments".to_string(), TaxonomyValue::String(comments));
         }
 
         data.push(node_data);
@@ -180,13 +199,25 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
                 names[idx] = name_txt.clone();
             }
 
-            // Store all name types in data
-            let name_key = format!("name_{}", name_class.replace(" ", "_"));
-            data[idx].insert(name_key, serde_json::Value::String(name_txt));
+            // Store all name types using the TaxonomyName struct
+            let taxonomy_name = TaxonomyName {
+                name_class: name_class.clone(),
+                name_text: name_txt,
+                unique_name: if unique_name.is_empty() {
+                    None
+                } else {
+                    Some(unique_name)
+                },
+            };
 
-            if !unique_name.is_empty() {
-                let unique_key = format!("unique_name_{}", name_class.replace(" ", "_"));
-                data[idx].insert(unique_key, serde_json::Value::String(unique_name));
+            // Get or create the names vector for this taxon
+            let names_key = "names";
+            let names_array = data[idx]
+                .entry(names_key.to_string())
+                .or_insert_with(|| TaxonomyValue::Array(Vec::new()));
+
+            if let Some(arr) = names_array.as_array_mut() {
+                arr.push(taxonomy_name.to_taxonomy_value());
             }
         }
     }
@@ -263,7 +294,7 @@ where
                 .unwrap_or_default()
         };
 
-        // Extract data fields
+        // Extract data fields with proper types
         let node_data = tax.data(key.clone())?;
         let embl_code = node_data
             .get("embl_code")
@@ -271,36 +302,44 @@ where
             .unwrap_or("");
         let division_id = node_data
             .get("division_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("0");
+            .and_then(|v| v.as_i64())
+            .map(|i| i.to_string())
+            .unwrap_or_else(|| "".to_string());
         let inherited_div_flag = node_data
             .get("inherited_div_flag")
-            .and_then(|v| v.as_str())
-            .unwrap_or("0");
+            .and_then(|v| v.as_bool())
+            .map(|b| if b { "1" } else { "0" })
+            .unwrap_or("");
         let genetic_code_id = node_data
             .get("genetic_code_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("1");
-        let inherited_GC_flag = node_data
-            .get("inherited_GC_flag")
-            .and_then(|v| v.as_str())
-            .unwrap_or("0");
+            .and_then(|v| v.as_i64())
+            .map(|i| i.to_string())
+            .unwrap_or_else(|| "".to_string());
+        let inherited_gc_flag = node_data
+            .get("inherited_gc_flag")
+            .and_then(|v| v.as_bool())
+            .map(|b| if b { "1" } else { "0" })
+            .unwrap_or("");
         let mitochondrial_genetic_code_id = node_data
             .get("mitochondrial_genetic_code_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("0");
-        let inherited_MGC_flag = node_data
-            .get("inherited_MGC_flag")
-            .and_then(|v| v.as_str())
-            .unwrap_or("0");
-        let GenBank_hidden_flag = node_data
-            .get("GenBank_hidden_flag")
-            .and_then(|v| v.as_str())
-            .unwrap_or("0");
+            .and_then(|v| v.as_i64())
+            .map(|i| i.to_string())
+            .unwrap_or_else(|| "".to_string());
+        let inherited_mgc_flag = node_data
+            .get("inherited_mgc_flag")
+            .and_then(|v| v.as_bool())
+            .map(|b| if b { "1" } else { "0" })
+            .unwrap_or("");
+        let genbank_hidden_flag = node_data
+            .get("genbank_hidden_flag")
+            .and_then(|v| v.as_bool())
+            .map(|b| if b { "1" } else { "0" })
+            .unwrap_or("");
         let hidden_subtree_root_flag = node_data
             .get("hidden_subtree_root_flag")
-            .and_then(|v| v.as_str())
-            .unwrap_or("0");
+            .and_then(|v| v.as_bool())
+            .map(|b| if b { "1" } else { "0" })
+            .unwrap_or("");
         let comments = node_data
             .get("comments")
             .and_then(|v| v.as_str())
@@ -316,23 +355,22 @@ where
         )?;
 
         // Write all alternative names from data
-        for (data_key, value) in node_data.iter() {
-            if data_key.starts_with("name_") && data_key != "name_scientific_name" {
-                let name_class = data_key.strip_prefix("name_").unwrap().replace("_", " ");
-                let name_txt = value.as_str().unwrap_or("");
-                let unique_name_key =
-                    format!("unique_name_{}", data_key.strip_prefix("name_").unwrap());
-                let unique_name = node_data
-                    .get(&unique_name_key)
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
-                write_names_row(
-                    &mut name_writer,
-                    &format!("{}", &key),
-                    name_txt,
-                    unique_name,
-                    &name_class,
-                )?;
+        if let Some(names_value) = node_data.get("names") {
+            if let Some(names_array) = names_value.as_array() {
+                for name_value in names_array {
+                    if let Some(tax_name) = TaxonomyName::from_taxonomy_value(name_value) {
+                        // Skip scientific name as it's already written above
+                        if tax_name.name_class != "scientific name" {
+                            write_names_row(
+                                &mut name_writer,
+                                &format!("{}", &key),
+                                &tax_name.name_text,
+                                tax_name.unique_name.as_deref().unwrap_or(""),
+                                &tax_name.name_class,
+                            )?;
+                        }
+                    }
+                }
             }
         }
 
@@ -348,10 +386,10 @@ where
                 division_id,
                 inherited_div: inherited_div_flag,
                 genetic_code: genetic_code_id,
-                inherited_gc: inherited_GC_flag,
+                inherited_gc: inherited_gc_flag,
                 mito_gc: mitochondrial_genetic_code_id,
-                inherited_mgc: inherited_MGC_flag,
-                genbank_hidden: GenBank_hidden_flag,
+                inherited_mgc: inherited_mgc_flag,
+                genbank_hidden: genbank_hidden_flag,
                 subtree_hidden: hidden_subtree_root_flag,
                 comments,
             },
@@ -458,19 +496,33 @@ mod tests {
             Some(("561", 1.))
         );
 
-        // Check that node data fields are loaded
+        // Check that node data fields are loaded with proper types
         let data_562 = Taxonomy::<&str>::data(&tax, "562").unwrap();
         assert_eq!(
-            data_562.get("genetic_code_id").and_then(|v| v.as_str()),
-            Some("11")
+            data_562.get("genetic_code_id").and_then(|v| v.as_i64()),
+            Some(11)
+        );
+        // Check boolean flags are parsed correctly
+        assert_eq!(
+            data_562.get("genbank_hidden_flag").and_then(|v| v.as_bool()),
+            Some(true)
         );
 
         // Check that alternative names are stored
-        assert!(data_562.contains_key("name_common_name"));
-        assert_eq!(
-            data_562.get("name_common_name").and_then(|v| v.as_str()),
-            Some("E. coli")
-        );
+        assert!(data_562.contains_key("names"));
+        let names_array = data_562.get("names").and_then(|v| v.as_array()).unwrap();
+        let common_name = names_array
+            .iter()
+            .find_map(|v| {
+                let name = TaxonomyName::from_taxonomy_value(v)?;
+                if name.name_class == "common name" {
+                    Some(name.name_text)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        assert_eq!(common_name, "E. coli");
 
         let out = path.join("out");
         save::<&str, _, _>(&tax, &out).unwrap();
@@ -512,22 +564,32 @@ mod tests {
             vec!["562"]
         );
 
-        // Check that data fields are preserved through save/load cycle
+        // Check that data fields are preserved through save/load cycle with proper types
         let data_562_after = Taxonomy::<&str>::data(&tax2, "562").unwrap();
         assert_eq!(
             data_562_after
                 .get("genetic_code_id")
-                .and_then(|v| v.as_str()),
-            Some("11")
+                .and_then(|v| v.as_i64()),
+            Some(11)
         );
 
         // Check that alternative names are preserved
-        assert!(data_562_after.contains_key("name_common_name"));
-        assert_eq!(
-            data_562_after
-                .get("name_common_name")
-                .and_then(|v| v.as_str()),
-            Some("E. coli")
-        );
+        assert!(data_562_after.contains_key("names"));
+        let names_array_after = data_562_after
+            .get("names")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        let common_name_after = names_array_after
+            .iter()
+            .find_map(|v| {
+                let name = TaxonomyName::from_taxonomy_value(v)?;
+                if name.name_class == "common name" {
+                    Some(name.name_text)
+                } else {
+                    None
+                }
+            })
+            .unwrap();
+        assert_eq!(common_name_after, "E. coli");
     }
 }

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -23,10 +23,19 @@ struct TaxonomyName {
 impl TaxonomyName {
     fn to_taxonomy_value(&self) -> TaxonomyValue {
         let mut map = HashMap::new();
-        map.insert("name_class".to_string(), TaxonomyValue::String(self.name_class.clone()));
-        map.insert("name_text".to_string(), TaxonomyValue::String(self.name_text.clone()));
+        map.insert(
+            "name_class".to_string(),
+            TaxonomyValue::String(self.name_class.clone()),
+        );
+        map.insert(
+            "name_text".to_string(),
+            TaxonomyValue::String(self.name_text.clone()),
+        );
         if let Some(ref unique) = self.unique_name {
-            map.insert("unique_name".to_string(), TaxonomyValue::String(unique.clone()));
+            map.insert(
+                "unique_name".to_string(),
+                TaxonomyValue::String(unique.clone()),
+            );
         }
         TaxonomyValue::Object(map)
     }
@@ -35,7 +44,10 @@ impl TaxonomyName {
         if let TaxonomyValue::Object(map) = value {
             let name_class = map.get("name_class")?.as_str()?.to_string();
             let name_text = map.get("name_text")?.as_str()?.to_string();
-            let unique_name = map.get("unique_name").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let unique_name = map
+                .get("unique_name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
             Some(TaxonomyName {
                 name_class,
                 name_text,
@@ -75,7 +87,7 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
     let mut tax_ids: Vec<String> = Vec::new();
     let mut parents: Vec<String> = Vec::new();
     let mut ranks: Vec<TaxRank> = Vec::new();
-    let mut data: Vec<HashMap<String, serde_json::Value>> = Vec::new();
+    let mut data: Vec<HashMap<String, TaxonomyValue>> = Vec::new();
     let mut tax_to_idx: HashMap<String, usize> = HashMap::new();
 
     for (ix, line) in BufReader::new(nodes_file).lines().enumerate() {
@@ -89,7 +101,7 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         let tax_id = fields.remove(0).trim().to_string();
         let parent_tax_id = fields.remove(0).trim().to_string();
         let rank = TaxRank::from_str(fields.remove(0).trim())?;
-        let embl_code = fields.remove(0).trim();
+        let embl_code = fields.remove(0).trim().to_string();
         let division_id = fields.remove(0).trim().parse::<i64>().ok();
         let inherited_div_flag = fields.remove(0).trim() == "1";
         let genetic_code_id = fields.remove(0).trim().parse::<i64>().ok();
@@ -116,10 +128,7 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         // Store all node fields in data HashMap with proper types
         let mut node_data = HashMap::new();
         if !embl_code.is_empty() {
-            node_data.insert(
-                "embl_code".to_string(),
-                TaxonomyValue::String(embl_code.to_string()),
-            );
+            node_data.insert("embl_code".to_string(), TaxonomyValue::String(embl_code));
         }
         if let Some(div_id) = division_id {
             node_data.insert("division_id".to_string(), TaxonomyValue::Integer(div_id));
@@ -197,27 +206,28 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
         if let Some(&idx) = tax_to_idx.get(&tax_id) {
             if name_class == "scientific name" {
                 names[idx] = name_txt.clone();
-            }
+            } else {
+                // Store non-scientific name types in data to avoid duplication
+                // (scientific name is already in the main names vector)
+                let taxonomy_name = TaxonomyName {
+                    name_class: name_class.clone(),
+                    name_text: name_txt,
+                    unique_name: if unique_name.is_empty() {
+                        None
+                    } else {
+                        Some(unique_name)
+                    },
+                };
 
-            // Store all name types using the TaxonomyName struct
-            let taxonomy_name = TaxonomyName {
-                name_class: name_class.clone(),
-                name_text: name_txt,
-                unique_name: if unique_name.is_empty() {
-                    None
-                } else {
-                    Some(unique_name)
-                },
-            };
+                // Get or create the names vector for this taxon
+                let names_key = "names";
+                let names_array = data[idx]
+                    .entry(names_key.to_string())
+                    .or_insert_with(|| TaxonomyValue::Array(Vec::new()));
 
-            // Get or create the names vector for this taxon
-            let names_key = "names";
-            let names_array = data[idx]
-                .entry(names_key.to_string())
-                .or_insert_with(|| TaxonomyValue::Array(Vec::new()));
-
-            if let Some(arr) = names_array.as_array_mut() {
-                arr.push(taxonomy_name.to_taxonomy_value());
+                if let Some(arr) = names_array.as_array_mut() {
+                    arr.push(taxonomy_name.to_taxonomy_value());
+                }
             }
         }
     }
@@ -383,11 +393,11 @@ where
                 parent: &parent,
                 rank: rank.to_ncbi_rank(),
                 embl_code,
-                division_id,
+                division_id: &division_id,
                 inherited_div: inherited_div_flag,
-                genetic_code: genetic_code_id,
+                genetic_code: &genetic_code_id,
                 inherited_gc: inherited_gc_flag,
-                mito_gc: mitochondrial_genetic_code_id,
+                mito_gc: &mitochondrial_genetic_code_id,
                 inherited_mgc: inherited_mgc_flag,
                 genbank_hidden: genbank_hidden_flag,
                 subtree_hidden: hidden_subtree_root_flag,
@@ -504,7 +514,9 @@ mod tests {
         );
         // Check boolean flags are parsed correctly
         assert_eq!(
-            data_562.get("genbank_hidden_flag").and_then(|v| v.as_bool()),
+            data_562
+                .get("genbank_hidden_flag")
+                .and_then(|v| v.as_bool()),
             Some(true)
         );
 
@@ -591,5 +603,19 @@ mod tests {
             })
             .unwrap();
         assert_eq!(common_name_after, "E. coli");
+
+        // Test that alternative names can be found with find_all_by_name
+        let found_by_common = tax.find_all_by_name("E. coli");
+        assert_eq!(found_by_common.len(), 1);
+        assert_eq!(found_by_common[0], "562");
+
+        let found_by_scientific = tax.find_all_by_name("Escherichia coli");
+        assert_eq!(found_by_scientific.len(), 1);
+        assert_eq!(found_by_scientific[0], "562");
+
+        // Test finding by synonym
+        let found_by_synonym = tax.find_all_by_name("Bacillus coli");
+        assert_eq!(found_by_synonym.len(), 1);
+        assert_eq!(found_by_synonym[0], "562");
     }
 }

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -308,9 +308,18 @@ where
         // Extract data fields with proper types
         let node_data = tax.data(key.clone())?;
 
-        let (embl_code, division_id, inherited_div_flag, genetic_code_id,
-             inherited_gc_flag, mitochondrial_genetic_code_id, inherited_mgc_flag,
-             genbank_hidden_flag, hidden_subtree_root_flag, comments) = if include_extended {
+        let (
+            embl_code,
+            division_id,
+            inherited_div_flag,
+            genetic_code_id,
+            inherited_gc_flag,
+            mitochondrial_genetic_code_id,
+            inherited_mgc_flag,
+            genbank_hidden_flag,
+            hidden_subtree_root_flag,
+            comments,
+        ) = if include_extended {
             // Extract extended fields from data
             let embl_code = node_data
                 .get("embl_code")
@@ -361,14 +370,32 @@ where
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
 
-            (embl_code, division_id, inherited_div_flag, genetic_code_id,
-             inherited_gc_flag, mitochondrial_genetic_code_id, inherited_mgc_flag,
-             genbank_hidden_flag, hidden_subtree_root_flag, comments)
+            (
+                embl_code,
+                division_id,
+                inherited_div_flag,
+                genetic_code_id,
+                inherited_gc_flag,
+                mitochondrial_genetic_code_id,
+                inherited_mgc_flag,
+                genbank_hidden_flag,
+                hidden_subtree_root_flag,
+                comments,
+            )
         } else {
             // Use empty/default values for backwards compatibility
-            ("", "".to_string(), "", "".to_string(),
-             "", "".to_string(), "",
-             "", "", "")
+            (
+                "",
+                "".to_string(),
+                "",
+                "".to_string(),
+                "",
+                "".to_string(),
+                "",
+                "",
+                "",
+                "",
+            )
         };
 
         // Write scientific name

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -204,10 +204,7 @@ pub fn load<P: AsRef<Path>>(ncbi_directory: P) -> TaxonomyResult<GeneralTaxonomy
 }
 
 /// Helper function to write a single row to nodes.dmp
-fn write_nodes_row(
-    writer: &mut BufWriter<std::fs::File>,
-    row: &NodesRow,
-) -> std::io::Result<()> {
+fn write_nodes_row(writer: &mut BufWriter<std::fs::File>, row: &NodesRow) -> std::io::Result<()> {
     writeln!(
         writer,
         "{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|",

--- a/src/formats/ncbi.rs
+++ b/src/formats/ncbi.rs
@@ -203,9 +203,9 @@ fn write_nodes_row(
     subtree_hidden: &str,
     comments: &str,
 ) -> std::io::Result<()> {
-    write!(
+    writeln!(
         writer,
-        "{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\n",
+        "{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|\t{}\t|",
         tax_id, parent, rank, embl_code, division_id, inherited_div,
         genetic_code, inherited_gc, mito_gc, inherited_mgc,
         genbank_hidden, subtree_hidden, comments
@@ -220,9 +220,9 @@ fn write_names_row(
     unique_name: &str,
     name_class: &str,
 ) -> std::io::Result<()> {
-    write!(
+    writeln!(
         writer,
-        "{}\t|\t{}\t|\t{}\t|\t{}\t|\n",
+        "{}\t|\t{}\t|\t{}\t|\t{}\t|",
         tax_id, name, unique_name, name_class
     )
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -344,9 +344,7 @@ impl Taxonomy {
     fn to_json_tree_streaming(&self, py: Python<'_>) -> PyResult<PyObject> {
         let mut bytes = Vec::new();
         py_try!(json::save_tree_streaming::<_, &str, _>(
-            &mut bytes,
-            &self.tax,
-            None
+            &mut bytes, &self.tax, None
         ));
         Ok(PyBytes::new(py, &bytes).into())
     }
@@ -527,7 +525,13 @@ impl Taxonomy {
     ///
     /// Returns:
     ///     Value of the field or default if not found
-    fn get_field(&self, tax_id: &str, field: &str, default: Option<&PyAny>, py: Python<'_>) -> PyResult<PyObject> {
+    fn get_field(
+        &self,
+        tax_id: &str,
+        field: &str,
+        default: Option<&PyAny>,
+        py: Python<'_>,
+    ) -> PyResult<PyObject> {
         let data = py_try!(self.tax.data(tax_id));
         if let Some(value) = data.get(field) {
             Ok(json_value_to_pyobject(value))

--- a/src/python.rs
+++ b/src/python.rs
@@ -381,7 +381,7 @@ impl Taxonomy {
 
     /// to_newick(self)
     /// --
-    ///
+    /// Uses taxonomy ID for node names (e.g, for E. coli the node name is 562)
     /// Export a Taxonomy as a Newick-encoded byte string.
     fn to_newick(&self, py: Python<'_>) -> PyResult<PyObject> {
         let mut bytes = Vec::new();

--- a/src/python.rs
+++ b/src/python.rs
@@ -318,6 +318,9 @@ impl Taxonomy {
     /// --
     ///
     /// Export a Taxonomy as a JSON-encoded byte string in a tree format
+    /// Suggest using to_json_tree_streaming instead for large trees
+    /// with additional data available in the tree, this function may now OOM for users
+    /// perhaps limit this function to outputting the few fields previously available
     fn to_json_tree(&self, py: Python<'_>) -> PyResult<PyObject> {
         let mut bytes = Vec::new();
         py_try!(json::save::<_, &str, _>(

--- a/src/python.rs
+++ b/src/python.rs
@@ -329,6 +329,25 @@ impl Taxonomy {
         Ok(PyBytes::new(py, &bytes).into())
     }
 
+    /// to_json_tree_streaming(self)
+    /// --
+    ///
+    /// Export a Taxonomy as a JSON-encoded byte string in a tree format.
+    /// This version uses streaming/incremental writing for much better memory
+    /// efficiency with large taxonomies (e.g., full NCBI taxonomy with 2.5M+ nodes).
+    ///
+    /// Unlike to_json_tree(), which builds the entire tree structure in memory
+    /// before serialization, this writes JSON directly as it traverses the tree.
+    fn to_json_tree_streaming(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let mut bytes = Vec::new();
+        py_try!(json::save_tree_streaming::<_, &str, _>(
+            &mut bytes,
+            &self.tax,
+            None
+        ));
+        Ok(PyBytes::new(py, &bytes).into())
+    }
+
     /// to_json_node_links(self)
     /// --
     ///

--- a/src/python.rs
+++ b/src/python.rs
@@ -10,9 +10,8 @@ use pyo3::create_exception;
 use pyo3::exceptions::PyKeyError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyType};
-use serde_json::Value;
 
-use crate::base::InternalIndex;
+use crate::base::{InternalIndex, TaxonomyValue};
 use crate::json::JsonFormat;
 use crate::rank::TaxRank;
 use crate::Taxonomy as TaxonomyTrait;
@@ -30,18 +29,14 @@ macro_rules! py_try {
     };
 }
 
-fn json_value_to_pyobject(val: &Value) -> PyObject {
+fn json_value_to_pyobject(val: &TaxonomyValue) -> PyObject {
     Python::with_gil(|py| match val {
-        Value::Null => py.None(),
-        Value::Bool(b) => b.to_object(py),
-        Value::Number(n) => {
-            if let Some(n1) = n.as_i64() {
-                return n1.to_object(py);
-            }
-            n.as_f64().unwrap().to_object(py)
-        }
-        Value::String(s) => s.to_object(py),
-        Value::Array(arr) => {
+        TaxonomyValue::Null => py.None(),
+        TaxonomyValue::Bool(b) => b.to_object(py),
+        TaxonomyValue::Integer(n) => n.to_object(py),
+        TaxonomyValue::Float(f) => f.to_object(py),
+        TaxonomyValue::String(s) => s.to_object(py),
+        TaxonomyValue::Array(arr) => {
             let pylist = PyList::empty(py);
             for v in arr {
                 pylist
@@ -50,7 +45,7 @@ fn json_value_to_pyobject(val: &Value) -> PyObject {
             }
             pylist.to_object(py)
         }
-        Value::Object(obj) => {
+        TaxonomyValue::Object(obj) => {
             let pydict = PyDict::new(py);
             for (key, val) in obj.iter() {
                 pydict
@@ -64,7 +59,7 @@ fn json_value_to_pyobject(val: &Value) -> PyObject {
 
 /// The data returned when looking up a taxonomy by id or by name
 #[pyclass]
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TaxonomyNode {
     #[pyo3(get)]
     id: String,
@@ -75,7 +70,7 @@ pub struct TaxonomyNode {
     #[pyo3(get)]
     rank: String,
     // Ideally this would be private
-    extra: HashMap<String, Value>,
+    extra: HashMap<String, TaxonomyValue>,
 }
 
 #[pymethods]
@@ -318,9 +313,6 @@ impl Taxonomy {
     /// --
     ///
     /// Export a Taxonomy as a JSON-encoded byte string in a tree format
-    /// Suggest using to_json_tree_streaming instead for large trees
-    /// with additional data available in the tree, this function may now OOM for users
-    /// perhaps limit this function to outputting the few fields previously available
     fn to_json_tree(&self, py: Python<'_>) -> PyResult<PyObject> {
         let mut bytes = Vec::new();
         py_try!(json::save::<_, &str, _>(
@@ -328,23 +320,6 @@ impl Taxonomy {
             &self.tax,
             JsonFormat::Tree,
             None
-        ));
-        Ok(PyBytes::new(py, &bytes).into())
-    }
-
-    /// to_json_tree_streaming(self)
-    /// --
-    ///
-    /// Export a Taxonomy as a JSON-encoded byte string in a tree format.
-    /// This version uses streaming/incremental writing for much better memory
-    /// efficiency with large taxonomies (e.g., full NCBI taxonomy with 2.5M+ nodes).
-    ///
-    /// Unlike to_json_tree(), which builds the entire tree structure in memory
-    /// before serialization, this writes JSON directly as it traverses the tree.
-    fn to_json_tree_streaming(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let mut bytes = Vec::new();
-        py_try!(json::save_tree_streaming::<_, &str, _>(
-            &mut bytes, &self.tax, None
         ));
         Ok(PyBytes::new(py, &bytes).into())
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -339,7 +339,7 @@ impl Taxonomy {
         Ok(PyBytes::new(py, &bytes).into())
     }
 
-    /// to_ncbi(self, output_dir: str)
+    /// to_ncbi(self, output_dir: str, /, include_extended: bool = True)
     /// --
     ///
     /// Export a Taxonomy to NCBI format files (nodes.dmp and names.dmp).
@@ -347,8 +347,11 @@ impl Taxonomy {
     ///
     /// Args:
     ///     output_dir: Path to the directory where nodes.dmp and names.dmp will be written
-    fn to_ncbi(&self, output_dir: &str) -> PyResult<()> {
-        py_try!(ncbi::save::<&str, _, _>(&self.tax, output_dir));
+    ///     include_extended: If True (default), include all NCBI-specific fields and alternative names.
+    ///                      If False, only write basic taxonomy structure.
+    #[pyo3(signature = (output_dir, include_extended=true))]
+    fn to_ncbi(&self, output_dir: &str, include_extended: bool) -> PyResult<()> {
+        py_try!(ncbi::save::<&str, _, _>(&self.tax, output_dir, include_extended));
         Ok(())
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -170,7 +170,6 @@ impl TaxonomyNode {
             Ok(py.None())
         }
     }
-
 }
 
 /// The Taxonomy object provides the primary interface for exploring a

--- a/src/python.rs
+++ b/src/python.rs
@@ -171,26 +171,6 @@ impl TaxonomyNode {
         }
     }
 
-    /// Convenience properties for common NCBI fields
-    #[getter]
-    fn genetic_code_id(&self, py: Python<'_>) -> PyResult<PyObject> {
-        self.get("genetic_code_id", None, py)
-    }
-
-    #[getter]
-    fn embl_code(&self, py: Python<'_>) -> PyResult<PyObject> {
-        self.get("embl_code", None, py)
-    }
-
-    #[getter]
-    fn division_id(&self, py: Python<'_>) -> PyResult<PyObject> {
-        self.get("division_id", None, py)
-    }
-
-    #[getter]
-    fn mitochondrial_genetic_code_id(&self, py: Python<'_>) -> PyResult<PyObject> {
-        self.get("mitochondrial_genetic_code_id", None, py)
-    }
 }
 
 /// The Taxonomy object provides the primary interface for exploring a

--- a/src/python.rs
+++ b/src/python.rs
@@ -351,7 +351,11 @@ impl Taxonomy {
     ///                      If False, only write basic taxonomy structure.
     #[pyo3(signature = (output_dir, include_extended=true))]
     fn to_ncbi(&self, output_dir: &str, include_extended: bool) -> PyResult<()> {
-        py_try!(ncbi::save::<&str, _, _>(&self.tax, output_dir, include_extended));
+        py_try!(ncbi::save::<&str, _, _>(
+            &self.tax,
+            output_dir,
+            include_extended
+        ));
         Ok(())
     }
 

--- a/src/taxonomy.rs
+++ b/src/taxonomy.rs
@@ -1,6 +1,6 @@
+use crate::base::TaxonomyValue;
 use crate::errors::TaxonomyResult;
 use crate::rank::TaxRank;
-use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::{HashMap, VecDeque};
 use std::fmt::{Debug, Display};
@@ -98,9 +98,8 @@ where
     fn name(&'t self, tax_id: T) -> TaxonomyResult<&str>;
 
     /// Returns the additional data at the given tax id node
-    /// This is only used by the json taxonomy so the value is serde_json::Value
     /// By default it just returns an empty hashmap
-    fn data(&'t self, _tax_id: T) -> TaxonomyResult<Cow<'t, HashMap<String, Value>>> {
+    fn data(&'t self, _tax_id: T) -> TaxonomyResult<Cow<'t, HashMap<String, TaxonomyValue>>> {
         Ok(Cow::Owned(HashMap::new()))
     }
 

--- a/taxonomy.pyi
+++ b/taxonomy.pyi
@@ -19,6 +19,38 @@ class TaxonomyNode:
     def __eq__(self, other: object) -> bool: ...
     def __ne__(self, other: object) -> bool: ...
 
+    def get_data(self) -> dict:
+        """Get all extra data fields as a dictionary."""
+        ...
+
+    def get_data_keys(self) -> List[str]:
+        """Get list of all available data field keys."""
+        ...
+
+    def get(self, key: str, default: Any = None) -> Any:
+        """Get a data field value with optional default."""
+        ...
+
+    @property
+    def genetic_code_id(self) -> Optional[str]:
+        """NCBI genetic code ID."""
+        ...
+
+    @property
+    def embl_code(self) -> Optional[str]:
+        """NCBI EMBL code."""
+        ...
+
+    @property
+    def division_id(self) -> Optional[str]:
+        """NCBI division ID."""
+        ...
+
+    @property
+    def mitochondrial_genetic_code_id(self) -> Optional[str]:
+        """NCBI mitochondrial genetic code ID."""
+        ...
+
 class Taxonomy:
     """
     The Taxonomy object provides the primary interface for exploring a
@@ -65,6 +97,19 @@ class Taxonomy:
 
     def to_json_tree(self) -> bytes:
         """Export a Taxonomy as a JSON-encoded byte string in a tree format"""
+        ...
+
+    def to_json_tree_streaming(self) -> bytes:
+        """
+        Export a Taxonomy as a JSON-encoded byte string in a tree format.
+
+        This version uses streaming/incremental writing for much better memory
+        efficiency with large taxonomies (e.g., full NCBI taxonomy with 2.5M+ nodes).
+
+        Unlike to_json_tree(), which builds the entire tree structure in memory
+        before serialization, this writes JSON directly as it traverses the tree.
+        Use this for large NCBI taxonomies to avoid high memory usage.
+        """
         ...
 
     def to_json_node_links(self) -> bytes:
@@ -120,6 +165,32 @@ class Taxonomy:
         """
         Return a list of all the parent taxonomy nodes of the node id provided
         (including that node itself).
+        """
+        ...
+
+    def data(self, tax_id: str) -> dict:
+        """
+        Get all extra data fields for a taxonomy node as a dictionary.
+
+        Args:
+            tax_id: The taxonomy ID to look up
+
+        Returns:
+            Dictionary containing all additional fields from the taxonomy
+        """
+        ...
+
+    def get_field(self, tax_id: str, field: str, default: Any = None) -> Any:
+        """
+        Get a specific data field for a taxonomy node.
+
+        Args:
+            tax_id: The taxonomy ID to look up
+            field: Field name to retrieve
+            default: Default value if field doesn't exist (default: None)
+
+        Returns:
+            Value of the field or default if not found
         """
         ...
 

--- a/taxonomy.pyi
+++ b/taxonomy.pyi
@@ -99,19 +99,6 @@ class Taxonomy:
         """Export a Taxonomy as a JSON-encoded byte string in a tree format"""
         ...
 
-    def to_json_tree_streaming(self) -> bytes:
-        """
-        Export a Taxonomy as a JSON-encoded byte string in a tree format.
-
-        This version uses streaming/incremental writing for much better memory
-        efficiency with large taxonomies (e.g., full NCBI taxonomy with 2.5M+ nodes).
-
-        Unlike to_json_tree(), which builds the entire tree structure in memory
-        before serialization, this writes JSON directly as it traverses the tree.
-        Use this for large NCBI taxonomies to avoid high memory usage.
-        """
-        ...
-
     def to_json_node_links(self) -> bytes:
         """Export a Taxonomy as a JSON-encoded byte string in a node link format"""
         ...


### PR DESCRIPTION
This PR should address comments made in previous PR (closed) .

When importing taxonomy in ncbi (names.dmp, nodes.dmp)  format all annotations, including alternate names, will be put inside nodes with convenient  methods for accessing these attributes. 

For output, exporting in ncbi, json, and newick formats, should be straight forward. A new json export function to_json_tree_streaming was added to replace the existing to_json_tree function as the latter OOMed by instance (15G) with the new nodes and should probably be replaced the streaming version.  to_json_node_link does not appear to have a memory problem. newick format uses the taxonomy ID for node names (e.g, for E. coli the node name is 562) which was existing behavior. 

More tests were also added.

Overview of Changes Made


1. TaxonomyNode Python Class Enhancements
Added new methods to the TaxonomyNode class in [python.rs](http://python.rs/):

    get_data(): Returns all extra data fields as a Python dictionary
    get_data_keys(): Returns a list of all available data field keys
    get(key, default=None): Gets a data field with optional default value

    Property accessors for common NCBI fields:
        genetic_code_id
        embl_code
        division_id
        mitochondrial_genetic_code_id



Taxonomy Class Enhancements
Added new methods to the Taxonomy class:
    data(tax_id): Returns all extra data fields for a given taxid as a dictionary
    get_field(tax_id, field, default=None): Gets a specific field for a taxid with optional default



 Updated Documentation
Updated the from_ncbi docstring to document that all NCBI fields are now loaded.



How to Access Data from Python
Method 1: Via TaxonomyNode object

from taxonomy import Taxonomy

tax = Taxonomy.from_ncbi("/path/to/ncbi")
node = tax["562"]  # E. coli

- Access via properties
print(node.genetic_code_id)
print(node.embl_code)

- Access all data
data = node.get_data()
print(data.keys())

- Access specific field with default
value = node.get("name_common_name", "N/A")

Method 2: Via dict-like interface

- Already existed, now includes all new fields
node = tax["562"]
print(node["genetic_code_id"])
print(node["name_common_name"])




Method 3: Via Taxonomy object directly

- Get all data for a taxid
data = tax.data("562")

- Get specific field
genetic_code = tax.get_field("562", "genetic_code_id")
Available Data Fields

    From nodes.dmp:
        embl_code
        division_id
        inherited_div_flag
        genetic_code_id
        inherited_GC_flag
        mitochondrial_genetic_code_id
        inherited_MGC_flag
        GenBank_hidden_flag
        hidden_subtree_root_flag
        comments

    From names.dmp:
        name_scientific_name
        name_common_name
        name_synonym
        name_authority
        name_blast_name
        name_genbank_common_name
        unique_name_* (for any name type that has a unique name)

    And many others depending on what's in the names.dmp file
    All attributes are now fully accessible from Python through multiple convenient interfaces!



The best way to handle missing data fields is to use the .get() method instead of the dict-like bracket notation.
I already implemented this in the Python bindings. Here are the recommended approaches:

1. Use .get() method with default value (Recommended)

- Safe - returns None or your default if key doesn't exist
common_name = node.get("name_common_name", "N/A")
genetic_code = node.get("genetic_code_id", "1")

- Or check if None
common_name = node.get("name_common_name")
if common_name is not None:
    print(f"Common name: {common_name}")



2. Use try-except for bracket notation

try:
    common_name = node["name_common_name"]
except KeyError:
    common_name = "N/A"



3. Check data keys first

data = node.get_data()
if "name_common_name" in data:
    common_name = data["name_common_name"]
else:
    common_name = "N/A"



4. Use the Taxonomy object's get_field method

- Also supports defaults
common_name = tax.get_field("562", "name_common_name", "N/A")
Best Practice Summary
For optional fields (like alternative names):



✓ node.get("name_common_name", "N/A")  # Good
✗ node["name_common_name"]              # Bad - will error if missing

For required fields (like genetic_code_id):

✓ node["genetic_code_id"]               # OK - should always exist
✓ node.genetic_code_id                  # OK - convenience property
✓ node.get("genetic_code_id", "1")      # Also OK - extra safe with default
The .get() method follows Python's dict interface convention and is the idiomatic way to handle potentially missing keys.