### PR TITLE
add TaxonomyNode class to python lib

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -627,6 +627,7 @@ impl TaxonomyIterator {
 #[pymodule]
 fn taxonomy(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Taxonomy>()?;
+    m.add_class::<TaxonomyNode>()?;
     m.add("TaxonomyError", py.get_type::<TaxonomyError>())?;
 
     Ok(())


### PR DESCRIPTION
Adds the `TaxonomyNode` class so that it can be imported via Python and used for type annotation:

```python
from taxonomy import TaxonomyNode

node: TaxonomyNode
```