### PR TITLE
Fix remove() corrupting parent indices and leaking data array

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -292,11 +292,14 @@ impl GeneralTaxonomy {
         self.parent_distances.remove(idx);
         self.ranks.remove(idx);
         self.names.remove(idx);
+        self.data.remove(idx);
 
-        // everything after `tax_id` in parents needs to get decremented by 1
-        // because we've changed the actual array size
-        for parent in self.parent_ids.iter_mut().skip(idx + 1) {
-            if *parent > 0 {
+        // all parent indices pointing to positions after the removed node must be
+        // decremented by 1, because the array shifted. This applies to every element
+        // (not just those after idx), since an out-of-order taxonomy can have parents
+        // with larger indices than their children.
+        for parent in self.parent_ids.iter_mut() {
+            if *parent > idx {
                 *parent -= 1;
             }
         }
@@ -521,6 +524,30 @@ mod tests {
         assert_eq!(tax.lineage("562").unwrap(), vec!["562", "1"]);
         // can't remove root
         assert!(tax.remove("1").is_err());
+    }
+
+    #[test]
+    fn remove_then_add_then_prune_preserves_nodes() {
+        use crate::edit::prune_to;
+
+        // Reproduce DEV-9780: removing a node, adding it back under a new parent,
+        // then pruning should not lose unrelated nodes or panic.
+        let mut tax = create_test_taxonomy();
+
+        // Remove "2" (Bacteria), which is a child of root and parent of "562"
+        tax.remove("2").unwrap();
+
+        // Add "2" back directly under root
+        tax.add("1", "2").unwrap();
+
+        // Prune to keep "562" (E. coli). Before the fix, "562" was unreachable
+        // from root after the remove+add, so the pruned taxonomy was empty.
+        let pruned = prune_to(&tax, &["562"], false).unwrap();
+
+        // "562" must be present and reachable
+        assert!(pruned.to_internal_index("562").is_ok());
+        // Root must be present
+        assert_eq!(Taxonomy::<&str>::root(&pruned), "1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes DEV-9780: pruning after remove+add would panic or silently drop nodes:

<details>

```python
# load taxonomy from NCBI tax dump
taxa = Taxonomy.from_ncbi('data/taxonomy')

# prove this exists, it should print out:
# <TaxonomyNode (id="555778" rank="strain" name="Halothiobacillus neapolitanus c2")>
print(taxa.node('555778'))

# get rid of the human node because we want to move it under root
taxa.remove_node('9606')

# add the node back under root
taxa.add_node('1', '9606', 'Homo sapiens', 'species')

# prune the taxonomy
pruned = taxa.prune(keep=["555778"])

# the H. neapolitanus node no longer exists, this will print None
print(pruned.node("555778"))

# this throws an exception:
# thread '<unnamed>' panicked at 'index out of bounds: the len is 0 but the index is 0', src/base.rs:316:10
# note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
print(pruned.root)
```
</details>

The issue was caused by two bugs in `.remove`:

1. the `idx` was never actually removed from `self.data`
2. The logic for updating parent IDs was wrong. It seems to assume that parent IDs is sorted by internal index, which isn't true. The fix is to iterate through each index item, checking if it's greater than the removed index, and decrementing it if true.
